### PR TITLE
fix: serialize master account ops via queue, patch UTXO race conditio…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,19 @@
-NEXT_PUBLIC_TWILIGHT_PRICE_WS=wss://twilight.rest/ws
-NEXT_PUBLIC_TWILIGHT_PRICE_REST_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyaWQiOiJ0ZXN0X3VzZXIiLCJpc19hZG1pbiI6ZmFsc2UsImV4cCI6NDgzNzE0Mzk1OSwiaWF0IjoxNjgzNTQzOTU5fQ.jn1u6__HRuqSHk8kXXlCY4FXli1F5V7UzNHP_8OfC78
-NEXT_PUBLIC_TWILIGHT_API_RPC=https://nyks-staging.com/tendermint/
-NEXT_PUBLIC_TWILIGHT_API_REST=https://nyks-staging.com/rest/
-NEXT_PUBLIC_ZKOS_API_ENDPOINT=https://nyks-staging.com/zkos/api/
-NEXT_PUBLIC_TWILIGHT_PRICE_REST=https://twilight.rest/api
-NEXT_PUBLIC_RELAYER_ENDPOINT=https://twilight.rest/relayer/
-NEXT_PUBLIC_CLIENT_ENDPOINT=https://twilight.rest/clientapi/
+NEXT_PUBLIC_TWILIGHT_PRICE_WS=wss://relayer.twilight.rest/ws
+NEXT_PUBLIC_TWILIGHT_PRICE_REST_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyaWQiOiJ0ZXN0X3VzZXIiLCJpc19hZG1pbiI6ZmFsc2UsImV4cCI6NDgzNzE0Mzk1OSwiaWF0IjoxNjgzNTQzOTU5fQ.jn1u6HRuqSHk8kXXlCY4FXli1F5V7UzNHP_8OfC78
+NEXT_PUBLIC_TWILIGHT_API_RPC=https://rpc.twilight.rest/
+NEXT_PUBLIC_TWILIGHT_API_REST=https://lcd.twilight.rest/
+NEXT_PUBLIC_ZKOS_API_ENDPOINT=https://nykschain.twilight.rest/zkos/
+NEXT_PUBLIC_TWILIGHT_PRICE_REST=https://relayer.twilight.rest/api
+NEXT_PUBLIC_RELAYER_ENDPOINT=https://relayer.twilight.rest/relayer/
+NEXT_PUBLIC_CLIENT_ENDPOINT=https://relayer.twilight.rest/clientapi/
 NEXT_PUBLIC_FAUCET_ENDPOINT=https://faucet-rpc.twilight.rest
-PRICE_ORACLE_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyaWQiOiJ0ZXN0X3VzZXIiLCJpc19hZG1pbiI6ZmFsc2UsImV4cCI6NDgzNzE0Mzk1OSwiaWF0IjoxNjgzNTQzOTU5fQ.jn1u6__HRuqSHk8kXXlCY4FXli1F5V7UzNHP_8OfC78
-VERCEL_URL=localhost:3000
+PRICE_ORACLE_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyaWQiOiJ0ZXN0X3VzZXIiLCJpc19hZG1pbiI6ZmFsc2UsImV4cCI6NDgzNzE0Mzk1OSwiaWF0IjoxNjgzNTQzOTU5fQ.jn1u6HRuqSHk8kXXlCY4FXli1F5V7UzNHP_8OfC78
+VERCEL_URL=https://web.twilight.rest/
 
-NEXT_PUBLIC_EXPLORER_URL=https://explorer.twilight.rest
+NEXT_PUBLIC_EXPLORER_URL=https://explorer.twilight.org/nyks
 NEXT_PUBLIC_KYC_ENDPOINT=https://zk-kyc.twilight.rest
 
 NEXT_PUBLIC_UMAMI_SRC=https://umami-production-328f.up.railway.app/script.js
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=66f03cb8-635a-4cc2-9cfa-39abc727d504
-NEXT_PUBLIC_MANDATORY_KYC=true
+NEXT_PUBLIC_MANDATORY_KYC=false
 NEXT_PUBLIC_TWILIGHT_NETWORK_TYPE=testnet

--- a/app/_components/trade/details/details.client.tsx
+++ b/app/_components/trade/details/details.client.tsx
@@ -86,14 +86,24 @@ const DetailsPanel = () => {
 
       const updatedAccount = zkAccounts.find(account => account.address === trade.accountAddress);
 
-      const balance = Math.round(Big(settledData.available_margin).toNumber())
-
       if (!updatedAccount) {
+        // useSyncTrades may have already cleaned up this account before we
+        // finished.  If the trade is gone or already SETTLED, treat it as a
+        // success rather than showing a false error.
+        const currentTrade = tradeOrders.find((t) => t.uuid === trade.uuid);
+        if (!currentTrade || currentTrade.orderStatus === "SETTLED") {
+          toast({
+            title: "Position closed",
+            description: "Your position has been closed successfully.",
+          });
+          return;
+        }
+
         toast({
           title: "Failed to settle position",
           description: "Failed to find account",
           variant: "error",
-        })
+        });
         return;
       }
 

--- a/app/_components/trade/order/forms/limit.client.tsx
+++ b/app/_components/trade/order/forms/limit.client.tsx
@@ -14,6 +14,7 @@ import { Text } from "@/components/typography";
 import { sendTradeOrder } from "@/lib/api/client";
 import { queryTradeOrder } from '@/lib/api/relayer';
 import { queryTransactionHashes } from "@/lib/api/rest";
+import { queryUtxoForAddress } from "@/lib/api/zkos";
 import cn from "@/lib/cn";
 import { retry } from "@/lib/helpers";
 import useGetMarketStats from '@/lib/hooks/useGetMarketStats';
@@ -22,13 +23,15 @@ import { useToast } from "@/lib/hooks/useToast";
 import { usePriceFeed } from '@/lib/providers/feed';
 import { useGrid } from "@/lib/providers/grid";
 import { useSessionStore } from "@/lib/providers/session";
-import { useTwilightStore } from "@/lib/providers/store";
+import { useTwilightStore, useTwilightStoreApi } from "@/lib/providers/store";
 import BTC from "@/lib/twilight/denoms";
 import { createFundingToTradingTransferMsg } from '@/lib/twilight/wallet';
 import { createZkAccountWithBalance, createZkOrder } from "@/lib/twilight/zk";
 import { createQueryTradeOrderMsg } from '@/lib/twilight/zkos';
 import { ZkAccount } from '@/lib/types';
 import { ZkPrivateAccount } from '@/lib/zk/account';
+import { masterAccountQueue } from "@/lib/utils/masterAccountQueue";
+import { hasUtxoData, serializeTxid, waitForUtxoUpdate } from "@/lib/utils/waitForUtxoUpdate";
 import { useWallet } from "@cosmos-kit/react-lite";
 import Big from "big.js";
 import dayjs from 'dayjs';
@@ -42,6 +45,10 @@ const OrderLimitForm = () => {
   const { width } = useGrid();
   const { toast } = useToast();
   const marketStats = useGetMarketStats();
+
+  // Raw store API — lets queue tasks read the latest state at execution time
+  // instead of relying on a potentially-stale React closure.
+  const storeApi = useTwilightStoreApi();
 
   const btcAmountRef = useRef<HTMLInputElement>(null);
   const leverageRef = useRef<HTMLInputElement>(null);
@@ -261,6 +268,8 @@ const OrderLimitForm = () => {
         description: "Order is being placed, please do not close this page.",
       })
 
+      // Generate the new order account before entering the queue — this is
+      // pure in-memory work and does not touch the master UTXO.
       const { account: newTradingAccount } =
         await createZkAccountWithBalance({
           tag: "limit",
@@ -268,66 +277,110 @@ const OrderLimitForm = () => {
           signature: privateKey,
         });
 
-      const tag = `BTC ${action} ${newTradingAccount.address.slice(0, 6)}`
+      const tag = `BTC ${action} ${newTradingAccount.address.slice(0, 6)}`;
 
-      const senderZkPrivateAccount = await ZkPrivateAccount.create({
-        signature: privateKey,
-        existingAccount: tradingAccount,
-      });
+      // --- Master-account critical section (serialised via queue) -----------
+      let queueResult: { newZkAccount: ZkAccount; txId: string };
+      try {
+        queueResult = await masterAccountQueue.enqueue(async () => {
+          const currentTradingAccount = storeApi
+            .getState()
+            .zk.zkAccounts.find((a) => a.tag === "main");
 
-      const privateTxSingleResult = await senderZkPrivateAccount.privateTxSingle(
-        btcAmountInSats,
-        newTradingAccount.address
-      )
+          if (!currentTradingAccount) {
+            throw new Error("Master trading account not found");
+          }
 
-      if (!privateTxSingleResult.success) {
-        console.error(privateTxSingleResult.message);
+          if (!currentTradingAccount.isOnChain || !currentTradingAccount.value) {
+            throw new Error("Master trading account is not on-chain");
+          }
+
+          if ((currentTradingAccount.value ?? 0) < btcAmountInSats) {
+            throw new Error("Insufficient funds in master trading account");
+          }
+
+          const utxoBefore = await queryUtxoForAddress(currentTradingAccount.address);
+          const previousTxid = hasUtxoData(utxoBefore)
+            ? serializeTxid(utxoBefore.txid)
+            : "";
+
+          const senderZkPrivateAccount = await ZkPrivateAccount.create({
+            signature: privateKey,
+            existingAccount: currentTradingAccount,
+          });
+
+          const privateTxSingleResult =
+            await senderZkPrivateAccount.privateTxSingle(
+              btcAmountInSats,
+              newTradingAccount.address
+            );
+
+          if (!privateTxSingleResult.success) {
+            throw new Error(privateTxSingleResult.message);
+          }
+
+          const {
+            txId,
+            scalar: updatedTradingAccountScalar,
+            updatedAddress: updatedTradingAccountAddress,
+          } = privateTxSingleResult.data;
+
+          const utxoWait = await waitForUtxoUpdate(
+            senderZkPrivateAccount.get().address,
+            previousTxid
+          );
+          if (!utxoWait.success) {
+            console.warn("waitForUtxoUpdate timed out:", utxoWait.message);
+          }
+
+          const newZkAccount: ZkAccount = {
+            scalar: updatedTradingAccountScalar,
+            type: "Coin",
+            address: updatedTradingAccountAddress,
+            tag,
+            isOnChain: true,
+            value: btcAmountInSats,
+            createdAt: dayjs().unix(),
+          };
+
+          addZkAccount(newZkAccount);
+
+          updateZkAccount(currentTradingAccount.address, {
+            ...currentTradingAccount,
+            address: senderZkPrivateAccount.get().address,
+            scalar: senderZkPrivateAccount.get().scalar,
+            value: senderZkPrivateAccount.get().value,
+            isOnChain: senderZkPrivateAccount.get().isOnChain,
+          });
+
+          addTransactionHistory({
+            date: new Date(),
+            from: currentTradingAccount.address,
+            fromTag: "Trading Account",
+            to: updatedTradingAccountAddress,
+            toTag: tag,
+            tx_hash: txId,
+            type: "Transfer",
+            value: btcAmountInSats,
+          });
+
+          return { newZkAccount, txId };
+        });
+      } catch (err) {
+        console.error("masterAccountQueue task failed:", err);
         toast({
           title: "Error with submitting trade order",
-          description: "An error occurred when transferring funds from the trading account, please try again later.",
+          description:
+            err instanceof Error
+              ? err.message
+              : "An error occurred when transferring funds from the trading account, please try again later.",
           variant: "error",
-        })
+        });
         return;
       }
+      // --- End of critical section ------------------------------------------
 
-      // the naming is abit off, this updated trading account is the account used to place the order
-      const {
-        txId,
-        scalar: updatedTradingAccountScalar,
-        updatedAddress: updatedTradingAccountAddress,
-      } = privateTxSingleResult.data;
-
-      const newZkAccount = {
-        scalar: updatedTradingAccountScalar,
-        type: "Coin",
-        address: updatedTradingAccountAddress,
-        tag: tag,
-        isOnChain: true,
-        value: btcAmountInSats,
-        createdAt: dayjs().unix(),
-      }
-
-      // note: add zk account in case submit order fails
-      addZkAccount(newZkAccount as ZkAccount);
-
-      updateZkAccount(tradingAccount.address, {
-        ...tradingAccount,
-        address: senderZkPrivateAccount.get().address,
-        scalar: senderZkPrivateAccount.get().scalar,
-        value: senderZkPrivateAccount.get().value,
-        isOnChain: senderZkPrivateAccount.get().isOnChain,
-      })
-
-      addTransactionHistory({
-        date: new Date(),
-        from: tradingAccount.address,
-        fromTag: "Trading Account",
-        to: updatedTradingAccountAddress,
-        toTag: tag,
-        tx_hash: txId,
-        type: "Transfer",
-        value: btcAmountInSats,
-      });
+      const { newZkAccount } = queueResult;
 
       const leverage = parseInt(leverageRef.current?.value || "1");
 

--- a/app/_components/trade/order/forms/market.client.tsx
+++ b/app/_components/trade/order/forms/market.client.tsx
@@ -9,6 +9,7 @@ import { Text } from "@/components/typography";
 import { sendTradeOrder } from "@/lib/api/client";
 import { queryTradeOrder } from '@/lib/api/relayer';
 import { queryTransactionHashes } from "@/lib/api/rest";
+import { queryUtxoForAddress } from "@/lib/api/zkos";
 import cn from "@/lib/cn";
 import { retry } from '@/lib/helpers';
 import useGetMarketStats from '@/lib/hooks/useGetMarketStats';
@@ -17,7 +18,7 @@ import { useToast } from "@/lib/hooks/useToast";
 import { usePriceFeed } from "@/lib/providers/feed";
 import { useGrid } from "@/lib/providers/grid";
 import { useSessionStore } from "@/lib/providers/session";
-import { useTwilightStore } from "@/lib/providers/store";
+import { useTwilightStore, useTwilightStoreApi } from "@/lib/providers/store";
 import { useTwilight } from "@/lib/providers/twilight";
 import BTC, { BTCDenoms } from "@/lib/twilight/denoms";
 import { createFundingToTradingTransferMsg } from '@/lib/twilight/wallet';
@@ -25,6 +26,8 @@ import { createZkAccountWithBalance, createZkOrder } from "@/lib/twilight/zk";
 import { createQueryTradeOrderMsg } from '@/lib/twilight/zkos';
 import { ZkAccount } from '@/lib/types';
 import { ZkPrivateAccount } from '@/lib/zk/account';
+import { masterAccountQueue } from "@/lib/utils/masterAccountQueue";
+import { hasUtxoData, serializeTxid, waitForUtxoUpdate } from "@/lib/utils/waitForUtxoUpdate";
 import { WalletStatus } from "@cosmos-kit/core";
 import { useWallet } from "@cosmos-kit/react-lite";
 import Big from "big.js";
@@ -37,6 +40,10 @@ const OrderMarketForm = () => {
   const { width } = useGrid();
 
   const privateKey = useSessionStore((state) => state.privateKey);
+
+  // Raw store API — lets queue tasks read the latest state at execution time
+  // instead of relying on a potentially-stale React closure.
+  const storeApi = useTwilightStoreApi();
 
   const { isLoading: isSatsLoading } =
     useGetTwilightBTCBalance();
@@ -261,6 +268,8 @@ const OrderMarketForm = () => {
         description: "Order is being placed, please do not close this page.",
       })
 
+      // Generate the new order account before entering the queue — this is
+      // pure in-memory work and does not touch the master UTXO.
       const { account: newTradingAccount } =
         await createZkAccountWithBalance({
           tag: "market",
@@ -268,66 +277,120 @@ const OrderMarketForm = () => {
           signature: privateKey,
         });
 
-      const tag = `BTC ${type.toLowerCase()} ${newTradingAccount.address.slice(0, 6)}`
+      const tag = `BTC ${type.toLowerCase()} ${newTradingAccount.address.slice(0, 6)}`;
 
-      const senderZkPrivateAccount = await ZkPrivateAccount.create({
-        signature: privateKey,
-        existingAccount: tradingAccount,
-      });
+      // --- Master-account critical section (serialised via queue) -----------
+      // The queue guarantees only one task at a time touches the master UTXO,
+      // preventing double-spend races with useSyncTrades cleanup tasks.
+      let queueResult: { newZkAccount: ZkAccount; txId: string };
+      try {
+        queueResult = await masterAccountQueue.enqueue(async () => {
+        // Read fresh master account at execution time (not from React closure).
+        const currentTradingAccount = storeApi
+          .getState()
+          .zk.zkAccounts.find((a) => a.tag === "main");
 
-      const privateTxSingleResult = await senderZkPrivateAccount.privateTxSingle(
-        satsValue,
-        newTradingAccount.address
-      )
+        if (!currentTradingAccount) {
+          throw new Error("Master trading account not found");
+        }
 
-      if (!privateTxSingleResult.success) {
-        console.error(privateTxSingleResult.message);
+        if (!currentTradingAccount.isOnChain || !currentTradingAccount.value) {
+          throw new Error("Master trading account is not on-chain");
+        }
+
+        if ((currentTradingAccount.value ?? 0) < satsValue) {
+          throw new Error("Insufficient funds in master trading account");
+        }
+
+        // Snapshot the current UTXO txid so we can detect when the chain
+        // updates after broadcast.
+        const utxoBefore = await queryUtxoForAddress(currentTradingAccount.address);
+        const previousTxid = hasUtxoData(utxoBefore)
+          ? serializeTxid(utxoBefore.txid)
+          : "";
+
+        const senderZkPrivateAccount = await ZkPrivateAccount.create({
+          signature: privateKey,
+          existingAccount: currentTradingAccount,
+        });
+
+        const privateTxSingleResult =
+          await senderZkPrivateAccount.privateTxSingle(
+            satsValue,
+            newTradingAccount.address
+          );
+
+        if (!privateTxSingleResult.success) {
+          throw new Error(privateTxSingleResult.message);
+        }
+
+        const {
+          txId,
+          scalar: updatedTradingAccountScalar,
+          updatedAddress: updatedTradingAccountAddress,
+        } = privateTxSingleResult.data;
+
+        // Wait for the UTXO store to reflect the broadcast before releasing
+        // the lock, so the next queued task starts from consistent state.
+        const utxoWait = await waitForUtxoUpdate(
+          senderZkPrivateAccount.get().address,
+          previousTxid
+        );
+        if (!utxoWait.success) {
+          console.warn("waitForUtxoUpdate timed out:", utxoWait.message);
+        }
+
+        // Persist state updates atomically after UTXO is confirmed.
+        const newZkAccount: ZkAccount = {
+          scalar: updatedTradingAccountScalar,
+          type: "Coin",
+          address: updatedTradingAccountAddress,
+          tag,
+          isOnChain: true,
+          value: satsValue,
+          createdAt: dayjs().unix(),
+        };
+
+        // Add the new order account first so it is tracked even if a later
+        // step fails (recovery is possible via manual cleanup).
+        addZkAccount(newZkAccount);
+
+        updateZkAccount(currentTradingAccount.address, {
+          ...currentTradingAccount,
+          address: senderZkPrivateAccount.get().address,
+          scalar: senderZkPrivateAccount.get().scalar,
+          value: senderZkPrivateAccount.get().value,
+          isOnChain: senderZkPrivateAccount.get().isOnChain,
+        });
+
+        addTransactionHistory({
+          date: new Date(),
+          from: currentTradingAccount.address,
+          fromTag: "Trading Account",
+          to: updatedTradingAccountAddress,
+          toTag: tag,
+          tx_hash: txId,
+          type: "Transfer",
+          value: satsValue,
+        });
+
+          return { newZkAccount, txId };
+        });
+      } catch (err) {
+        console.error("masterAccountQueue task failed:", err);
         toast({
           title: "Error with submitting trade order",
-          description: "An error occurred when transferring funds from the trading account, please try again later.",
+          description:
+            err instanceof Error
+              ? err.message
+              : "An error occurred when transferring funds from the trading account, please try again later.",
           variant: "error",
-        })
+        });
         return;
       }
+      // --- End of critical section ------------------------------------------
 
-      // the naming is abit off, this updated trading account is the account used to place the order
-      const {
-        txId,
-        scalar: updatedTradingAccountScalar,
-        updatedAddress: updatedTradingAccountAddress,
-      } = privateTxSingleResult.data;
-
-      const newZkAccount = {
-        scalar: updatedTradingAccountScalar,
-        type: "Coin",
-        address: updatedTradingAccountAddress,
-        tag: tag,
-        isOnChain: true,
-        value: satsValue,
-        createdAt: dayjs().unix(),
-      }
-
-      // note: add zk account in case submit order fails
-      addZkAccount(newZkAccount as ZkAccount);
-
-      updateZkAccount(tradingAccount.address, {
-        ...tradingAccount,
-        address: senderZkPrivateAccount.get().address,
-        scalar: senderZkPrivateAccount.get().scalar,
-        value: senderZkPrivateAccount.get().value,
-        isOnChain: senderZkPrivateAccount.get().isOnChain,
-      })
-
-      addTransactionHistory({
-        date: new Date(),
-        from: tradingAccount.address,
-        fromTag: "Trading Account",
-        to: updatedTradingAccountAddress,
-        toTag: tag,
-        tx_hash: txId,
-        type: "Transfer",
-        value: satsValue,
-      });
+      const { newZkAccount } = queueResult;
 
       const leverage = parseInt(leverageRef.current?.value || "1");
 

--- a/app/_components/trade/orderbook/my-trades.client.tsx
+++ b/app/_components/trade/orderbook/my-trades.client.tsx
@@ -248,8 +248,7 @@ const OrderMyTrades = () => {
     return {
       success: true,
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [toast, privateKey, removeZkAccount]);
+  }, [toast, privateKey, removeZkAccount, chainWallet]);
 
   // Memoize the callback functions to prevent unnecessary re-renders
   const handleSettleOrder = useCallback(async (tradeOrder: TradeOrder) => {
@@ -505,7 +504,12 @@ const OrderMyTrades = () => {
 
       console.log("trade order settled", settledTx?.tx_hash);
 
-      const result = await cleanupTradeOrder(privateKey, currentAccount);
+      // Pass the PnL-adjusted balance so the burn tx uses the correct on-chain
+      // value, not the original margin captured before settlement.
+      const result = await cleanupTradeOrder(privateKey, {
+        ...currentAccount,
+        value: newAccountBalance,
+      });
 
       if (!result.success) {
         toast({
@@ -616,50 +620,6 @@ const OrderMyTrades = () => {
         description: `Successfully cancelled ${tradeOrder.orderType.toLowerCase()} order`,
       });
 
-      const getZkAccountBalanceResult = await retry<
-        ReturnType<typeof getZkAccountBalance>,
-        {
-          zkAccountAddress: string;
-          signature: string;
-        }
-      >(
-        getZkAccountBalance,
-        30,
-        {
-          zkAccountAddress: tradeOrder.accountAddress,
-          signature: privateKey,
-        },
-        1000,
-        (result) => {
-          if (result.value) return true;
-
-          return false;
-        }
-      );
-
-      if (!getZkAccountBalanceResult.success) {
-        console.error("cancel order failed to get balance");
-        toast({
-          variant: "error",
-          title: "Error",
-          description: "Error with getting balance after cancelling order.",
-        });
-        return;
-      }
-
-      const { value: newAccountBalance } = getZkAccountBalanceResult.data;
-
-      if (!newAccountBalance) {
-        toast({
-          variant: "error",
-          title: "Error",
-          description: "Error with cancelling trade order",
-        });
-        return;
-      }
-
-      console.log("cancel account balance", newAccountBalance);
-
       const queryTradeOrderMsg = await createQueryTradeOrderMsg({
         address: tradeOrder.accountAddress,
         orderStatus: "CANCELLED",
@@ -680,7 +640,6 @@ const OrderMyTrades = () => {
 
       updateZkAccount(tradeOrder.accountAddress, {
         ...currentAccount,
-        value: newAccountBalance,
         type: "Coin",
       });
 
@@ -713,7 +672,7 @@ const OrderMyTrades = () => {
       if (!cleanupResult.success) {
         toast({
           title: "Error with cancelling trade order",
-          description: result.message,
+          description: cleanupResult.message,
           variant: "error",
         })
         return;

--- a/cloudfront-functions/redirects.js
+++ b/cloudfront-functions/redirects.js
@@ -1,0 +1,44 @@
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  
+  var redirects = {
+  "/design/components": {
+    "location": "/design",
+    "permanent": true
+  },
+  "/design/core": {
+    "location": "/design",
+    "permanent": true
+  },
+  "/btc-deposit-flow": {
+    "location": "/guides/btc-deposit-flow.html",
+    "permanent": false
+  },
+  "/dex-operations": {
+    "location": "/guides/dex-operations.html",
+    "permanent": false
+  },
+  "/lend-to-twilight-pool": {
+    "location": "/guides/lend-to-twilight-pool.html",
+    "permanent": false
+  }
+};
+  
+  if (redirects[uri]) {
+    var redirect = redirects[uri];
+    return {
+      statusCode: redirect.permanent ? 301 : 302,
+      statusDescription: redirect.permanent ? 'Moved Permanently' : 'Found',
+      headers: {
+        'location': { value: redirect.location }
+      }
+    };
+  }
+   // Append .html extension if URI doesn't have an extension and isn't a directory
+  // This handles Next.js static export pages like /test-mint-burn -> /test-mint-burn.html
+  if (!uri.includes('.') && !uri.endsWith('/')) {
+    request.uri = uri + '.html';
+  }
+  return request;
+}

--- a/lib/hooks/useSyncBalance.ts
+++ b/lib/hooks/useSyncBalance.ts
@@ -12,10 +12,16 @@ export const useSyncBalance = () => {
   const privateKey = useSessionStore((state) => state.privateKey);
   const { status } = useWallet();
 
-  // Filter accounts that need syncing upfront
+  // Filter accounts that need syncing upfront.
+  // The master account (tag === "main") is excluded because its balance and
+  // UTXO are exclusively managed by serialised queue operations.  Letting the
+  // background poller overwrite it mid-flight would corrupt optimistic updates.
   const accountsToSync = useMemo(() => {
     return zkAccounts.filter(
-      (account) => account.isOnChain && account.type !== "Memo"
+      (account) =>
+        account.isOnChain &&
+        account.type !== "Memo" &&
+        account.tag !== "main"
     );
   }, [zkAccounts]);
 

--- a/lib/hooks/useSyncTrades.tsx
+++ b/lib/hooks/useSyncTrades.tsx
@@ -1,19 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
-import { useTwilightStore } from "../providers/store";
+import { useTwilightStore, useTwilightStoreApi } from "../providers/store";
 import { createQueryTradeOrderMsg } from "../twilight/zkos";
 import { useSessionStore } from "../providers/session";
 import { queryTradeOrder } from "../api/relayer";
+import { queryUtxoForAddress } from "../api/zkos";
 import Big from "big.js";
 import { TradeOrder, ZkAccount } from "../types";
 import { useWallet } from "@cosmos-kit/react-lite";
 import { WalletStatus } from "@cosmos-kit/core";
-import { useCallback } from "react";
 import { ZkPrivateAccount } from "../zk/account";
 import { createZkAccount } from "../twilight/zk";
 import { useToast } from "./useToast";
 import Link from 'next/link';
 import BTC from '../twilight/denoms';
 import { queryTransactionHashes } from '../api/rest';
+import { masterAccountQueue } from "../utils/masterAccountQueue";
+import { hasUtxoData, serializeTxid, waitForUtxoUpdate } from "../utils/waitForUtxoUpdate";
 
 const statusToSkip = ["CANCELLED", "SETTLED", "LIQUIDATE"];
 
@@ -66,24 +68,21 @@ const tradeInfoKeysToTradeKey = {
 export const useSyncTrades = () => {
   const tradeOrders = useTwilightStore((state) => state.trade.trades);
   const removeTrade = useTwilightStore((state) => state.trade.removeTrade);
-
   const setNewTrades = useTwilightStore((state) => state.trade.setNewTrades);
   const addTradeHistory = useTwilightStore(
     (state) => state.trade_history.addTrade
   );
-
   const updateZkAccount = useTwilightStore((state) => state.zk.updateZkAccount);
-
-  const { toast } = useToast();
-
   const removeZkAccount = useTwilightStore((state) => state.zk.removeZkAccount);
-  const zkAccounts = useTwilightStore((state) => state.zk.zkAccounts);
-  const tradingAccount = zkAccounts.find((account) => account.tag === "main");
-
   const addTransactionHistory = useTwilightStore(
     (state) => state.history.addTransaction
   );
 
+  // Raw store API — queue tasks call storeApi.getState() to read the latest
+  // master account state at execution time, avoiding stale closures.
+  const storeApi = useTwilightStoreApi();
+
+  const { toast } = useToast();
   const { status, mainWallet } = useWallet();
 
   const chainWallet = mainWallet?.getChainWallet("nyks");
@@ -91,125 +90,10 @@ export const useSyncTrades = () => {
 
   const privateKey = useSessionStore((state) => state.privateKey);
 
-  const cleanupTradeOrder = useCallback(
-    async (privateKey: string, zkAccount: ZkAccount, tradeOrder: TradeOrder) => {
-      if (!twilightAddress || !tradingAccount) {
-        return {
-          success: false,
-          message: "An unexpected error occurred",
-        };
-      }
-
-      if (!zkAccount.value) {
-        return {
-          success: false,
-          message: "ZkAccount does not have a value",
-        };
-      }
-
-      const senderZkPrivateAccount = await ZkPrivateAccount.create({
-        signature: privateKey,
-        existingAccount: zkAccount,
-      });
-
-      console.log("senderZkPrivateAccount", senderZkPrivateAccount.get());
-
-      let privateTxSingleResult: any;
-
-      if (!tradingAccount.value || !tradingAccount.isOnChain) {
-        const newTradingAccount = await createZkAccount({
-          tag: "main",
-          signature: privateKey,
-        });
-
-        privateTxSingleResult = await senderZkPrivateAccount.privateTxSingle(
-          zkAccount.value,
-          newTradingAccount.address,
-          0
-        );
-      } else {
-        privateTxSingleResult = await senderZkPrivateAccount.privateTxSingle(
-          zkAccount.value,
-          tradingAccount.address,
-          tradingAccount.value
-        );
-      }
-
-      if (!privateTxSingleResult.success) {
-        return {
-          success: false,
-          message: privateTxSingleResult.message,
-        };
-      }
-
-      const {
-        scalar: updatedTradingAccountScalar,
-        txId,
-        updatedAddress: updatedTradingAccountAddress,
-      } = privateTxSingleResult.data;
-
-      updateZkAccount(tradingAccount.address, {
-        ...tradingAccount,
-        address: updatedTradingAccountAddress,
-        scalar: updatedTradingAccountScalar,
-        value: Big(zkAccount.value)
-          .add(tradingAccount.value || 0)
-          .toNumber(),
-        isOnChain: true,
-      });
-
-      addTransactionHistory({
-        date: new Date(),
-        from: zkAccount.address,
-        fromTag: zkAccount.tag,
-        to: updatedTradingAccountAddress,
-        toTag: "Trading Account",
-        tx_hash: txId,
-        type: "Transfer",
-        value: zkAccount.value,
-      });
-
-      removeZkAccount(zkAccount);
-      removeTrade(tradeOrder);
-
-      toast({
-        title: "Success",
-        description: (
-          <div className="opacity-90">
-            {`Successfully sent ${new BTC("sats", Big(zkAccount.value))
-              .convert("BTC")
-              .toString()} BTC to the Trading Account.`}
-            <Link
-              href={`${process.env.NEXT_PUBLIC_EXPLORER_URL as string}/txs/${txId}`}
-              target={"_blank"}
-              className="text-sm underline hover:opacity-100"
-            >
-              Explorer link
-            </Link>
-          </div>
-        )
-      })
-
-      return {
-        success: true,
-      };
-    },
-    [
-      toast,
-      updateZkAccount,
-      addTransactionHistory,
-      removeZkAccount,
-      tradingAccount,
-      twilightAddress,
-      removeTrade,
-    ]
-  );
-
   useQuery({
     queryKey: ["sync-trades", twilightAddress],
     queryFn: async () => {
       if (status !== WalletStatus.Connected) return true;
-
       if (tradeOrders.length === 0) return true;
 
       const updated = new Map<string, Partial<TradeOrder>>();
@@ -224,7 +108,7 @@ export const useSyncTrades = () => {
         });
 
         const queryTradeOrderRes = await queryTradeOrder(queryTradeOrderMsg);
-        const queryTxHashRes = await queryTransactionHashes(trade.accountAddress)
+        const queryTxHashRes = await queryTransactionHashes(trade.accountAddress);
 
         if (!queryTradeOrderRes || !queryTxHashRes.result) {
           continue;
@@ -233,40 +117,37 @@ export const useSyncTrades = () => {
         const traderOrderInfo = queryTradeOrderRes.result;
         const txHashData = queryTxHashRes.result;
 
-        const foundTxHashData = txHashData.filter((data) => data.order_status === traderOrderInfo.order_status)
+        const foundTxHashData = txHashData.filter(
+          (data) => data.order_status === traderOrderInfo.order_status
+        );
 
-        const updatedTradeData: Record<string, any> = {
-          tx_hash: foundTxHashData[0] ? foundTxHashData[0].tx_hash : undefined
+        const updatedTradeData: Record<string, unknown> = {
+          tx_hash: foundTxHashData[0] ? foundTxHashData[0].tx_hash : undefined,
         };
 
         for (const [key, value] of Object.entries(traderOrderInfo)) {
           const tradeKey =
             tradeInfoKeysToTradeKey[
-            key as keyof typeof tradeInfoKeysToTradeKey
+              key as keyof typeof tradeInfoKeysToTradeKey
             ];
 
-          if (!(tradeKey in trade)) {
-            continue;
-          }
+          if (!(tradeKey in trade)) continue;
 
-          let updatedValue = value;
+          let updatedValue: unknown = value;
 
           if (keysToUpdateNumber.includes(tradeKey)) {
-            updatedValue = new Big(value).toNumber();
+            updatedValue = new Big(value as string | number).toNumber();
           }
 
           const currentValue = trade[tradeKey as keyof TradeOrder];
-
-          if (currentValue === updatedValue) {
-            continue;
-          }
+          if (currentValue === updatedValue) continue;
 
           if (key === "order_status") {
             updated.set(trade.uuid, {
               isOpen:
                 traderOrderInfo.order_status === "CANCELLED" ||
-                  traderOrderInfo.order_status === "LIQUIDATE" ||
-                  traderOrderInfo.order_status === "SETTLED"
+                traderOrderInfo.order_status === "LIQUIDATE" ||
+                traderOrderInfo.order_status === "SETTLED"
                   ? false
                   : true,
             });
@@ -280,70 +161,238 @@ export const useSyncTrades = () => {
         }
       }
 
-      if (updated.size < 1) {
-        return true;
-      }
+      if (updated.size < 1) return true;
 
-      const mergedTrades: Array<TradeOrder> = [];
+      const mergedTrades: TradeOrder[] = [];
+
+      // At most one master-account cleanup is scheduled per cycle.
+      // Scheduling more would risk double-spending the same UTXO before the
+      // first cleanup's UTXO update is reflected in the oracle subscriber.
+      // The next 3-second poll picks up the remaining terminal orders.
+      let cleanupScheduled = false;
 
       for (const trade of tradeOrders) {
         const updatedTrade = updated.get(trade.uuid);
 
-        if (updatedTrade) {
-          const newTrade = {
-            ...trade,
-            ...updatedTrade,
-          };
+        if (!updatedTrade) {
+          mergedTrades.push(trade);
+          continue;
+        }
 
-          console.log("updatedTrade", updatedTrade);
+        const newTrade: TradeOrder = { ...trade, ...updatedTrade };
 
-          mergedTrades.push(newTrade);
+        console.log("updatedTrade", updatedTrade);
 
-          // update zk account balance
-          if (
-            newTrade.orderStatus === "SETTLED" ||
-            newTrade.orderStatus === "LIQUIDATE" ||
-            newTrade.orderStatus === "CANCELLED"
-          ) {
-            const newBalance = Math.round(newTrade.availableMargin);
+        mergedTrades.push(newTrade);
 
-            const existingZkAccount = zkAccounts.find(
-              (account) => account.address === newTrade.accountAddress
-            );
+        const isTerminal =
+          newTrade.orderStatus === "SETTLED" ||
+          newTrade.orderStatus === "LIQUIDATE" ||
+          newTrade.orderStatus === "CANCELLED";
 
-            if (existingZkAccount) {
-              if (newTrade.orderStatus === "LIQUIDATE") {
-                removeZkAccount(existingZkAccount)
-              }
-              else {
-                const zkAccountWithUpdatedData: ZkAccount = {
-                  ...existingZkAccount,
-                  value: newBalance,
-                  type: newTrade.orderStatus === "CANCELLED" ? "Coin" : "CoinSettled"
-                }
+        if (isTerminal) {
+          // Re-read zkAccounts from the store at this moment (not from a
+          // render-time closure) to avoid acting on a removed account.
+          const freshZkAccounts = storeApi.getState().zk.zkAccounts;
+          const existingZkAccount = freshZkAccounts.find(
+            (a) => a.address === newTrade.accountAddress
+          );
 
-                await cleanupTradeOrder(privateKey, zkAccountWithUpdatedData, newTrade);
-              }
+          if (existingZkAccount) {
+            if (newTrade.orderStatus === "LIQUIDATE") {
+              // The exchange already debited the master account on-chain;
+              // we only need to drop the local reference.
+              removeZkAccount(existingZkAccount);
+            } else if (!cleanupScheduled) {
+              // SETTLED or CANCELLED — merge the order-account balance back
+              // into the master account via a private transfer.  Serialised
+              // through the queue to prevent UTXO double-spend races.
+              cleanupScheduled = true;
 
+              const newBalance = Math.round(newTrade.availableMargin);
+              const accountAddress = newTrade.accountAddress;
+              const accountType: ZkAccount["type"] =
+                newTrade.orderStatus === "CANCELLED" ? "Coin" : "CoinSettled";
+              const tradeCopy = { ...newTrade };
+
+              masterAccountQueue
+                .enqueue(async () => {
+                  // Read state at task-execution time, not closure time.
+                  const state = storeApi.getState();
+                  const currentZkAccount = state.zk.zkAccounts.find(
+                    (a) => a.address === accountAddress
+                  );
+                  const currentTradingAccount = state.zk.zkAccounts.find(
+                    (a) => a.tag === "main"
+                  );
+
+                  // If the account was already cleaned up by another path, bail.
+                  if (!currentZkAccount) return;
+
+                  const zkAccountToSettle: ZkAccount = {
+                    ...currentZkAccount,
+                    value: newBalance,
+                    type: accountType,
+                  };
+
+                  if (!zkAccountToSettle.value) {
+                    console.warn(
+                      "useSyncTrades: order account has no value, skipping cleanup",
+                      accountAddress
+                    );
+                    return;
+                  }
+
+                  const senderZkPrivateAccount = await ZkPrivateAccount.create({
+                    signature: privateKey,
+                    existingAccount: zkAccountToSettle,
+                  });
+
+                  console.log(
+                    "useSyncTrades senderZkPrivateAccount",
+                    senderZkPrivateAccount.get()
+                  );
+
+                  let privateTxSingleResult: Awaited<
+                    ReturnType<typeof senderZkPrivateAccount.privateTxSingle>
+                  >;
+
+                  if (!currentTradingAccount?.isOnChain || !currentTradingAccount.value) {
+                    // Master account doesn't exist on-chain yet — create a
+                    // fresh one as the transfer destination.
+                    const freshMasterAccount = await createZkAccount({
+                      tag: "main",
+                      signature: privateKey,
+                    });
+
+                    privateTxSingleResult =
+                      await senderZkPrivateAccount.privateTxSingle(
+                        zkAccountToSettle.value,
+                        freshMasterAccount.address,
+                        0
+                      );
+                  } else {
+                    // Snapshot current master UTXO txid before broadcast.
+                    const utxoBefore = await queryUtxoForAddress(
+                      currentTradingAccount.address
+                    );
+                    const previousTxid = hasUtxoData(utxoBefore)
+                      ? serializeTxid(utxoBefore.txid)
+                      : "";
+
+                    privateTxSingleResult =
+                      await senderZkPrivateAccount.privateTxSingle(
+                        zkAccountToSettle.value,
+                        currentTradingAccount.address,
+                        currentTradingAccount.value
+                      );
+
+                    if (privateTxSingleResult.success) {
+                      const utxoWait = await waitForUtxoUpdate(
+                        privateTxSingleResult.data.updatedAddress,
+                        previousTxid
+                      );
+                      if (!utxoWait.success) {
+                        console.warn(
+                          "useSyncTrades waitForUtxoUpdate timed out:",
+                          utxoWait.message
+                        );
+                      }
+                    }
+                  }
+
+                  if (!privateTxSingleResult.success) {
+                    console.error(
+                      "useSyncTrades cleanup failed:",
+                      privateTxSingleResult.message
+                    );
+                    return;
+                  }
+
+                  const {
+                    scalar: updatedTradingAccountScalar,
+                    txId,
+                    updatedAddress: updatedTradingAccountAddress,
+                  } = privateTxSingleResult.data;
+
+                  // Re-read trading account one final time to get the key
+                  // for updateZkAccount (address may have changed if it was
+                  // recreated above).
+                  const latestTradingAccount = storeApi
+                    .getState()
+                    .zk.zkAccounts.find((a) => a.tag === "main");
+
+                  if (latestTradingAccount) {
+                    updateZkAccount(latestTradingAccount.address, {
+                      ...latestTradingAccount,
+                      address: updatedTradingAccountAddress,
+                      scalar: updatedTradingAccountScalar,
+                      value: Big(zkAccountToSettle.value)
+                        .add(latestTradingAccount.value ?? 0)
+                        .toNumber(),
+                      isOnChain: true,
+                    });
+                  }
+
+                  addTransactionHistory({
+                    date: new Date(),
+                    from: zkAccountToSettle.address,
+                    fromTag: zkAccountToSettle.tag,
+                    to: updatedTradingAccountAddress,
+                    toTag: "Trading Account",
+                    tx_hash: txId,
+                    type: "Transfer",
+                    value: zkAccountToSettle.value,
+                  });
+
+                  // Only remove the order account and trade record after the
+                  // transfer is confirmed, preserving recovery options on failure.
+                  removeZkAccount(zkAccountToSettle);
+                  removeTrade(tradeCopy);
+
+                  toast({
+                    title: "Success",
+                    description: (
+                      <div className="opacity-90">
+                        {`Successfully sent ${new BTC(
+                          "sats",
+                          Big(zkAccountToSettle.value)
+                        )
+                          .convert("BTC")
+                          .toString()} BTC to the Trading Account.`}
+                        <Link
+                          href={`${
+                            process.env.NEXT_PUBLIC_EXPLORER_URL as string
+                          }/txs/${txId}`}
+                          target={"_blank"}
+                          className="text-sm underline hover:opacity-100"
+                        >
+                          Explorer link
+                        </Link>
+                      </div>
+                    ),
+                  });
+                })
+                .catch((err) => {
+                  console.error("useSyncTrades cleanup queue task failed:", err);
+                });
             }
           }
+        }
 
-          // order status changed, add to history
-          if (updatedTrade.orderStatus) {
-            console.log(
-              "adding to history",
-              trade.orderStatus,
-              updatedTrade.orderStatus
-            );
-
-            addTradeHistory(newTrade);
-
-          }
-        } else {
-          mergedTrades.push(trade);
+        // Record every status transition to trade history.
+        if (updatedTrade.orderStatus) {
+          console.log(
+            "adding to history",
+            trade.orderStatus,
+            updatedTrade.orderStatus
+          );
+          addTradeHistory(newTrade);
         }
       }
 
+      // Always commit the updated trade statuses so the next poll cycle
+      // skips already-terminal orders (statusToSkip check at top of loop).
       setNewTrades(mergedTrades);
 
       return true;

--- a/lib/providers/store.tsx
+++ b/lib/providers/store.tsx
@@ -202,3 +202,19 @@ export const useTwilightStore = <T,>(
 
   return useStore(twilightStoreCtx, selector);
 };
+
+/**
+ * Returns the raw Zustand StoreApi so non-React code (e.g. queue tasks) can
+ * call storeApi.getState() to read the current state without stale closures.
+ */
+export const useTwilightStoreApi = (): StoreApi<AccountSlices> => {
+  const twilightStoreCtx = useContext(twilightStoreContext);
+
+  if (!twilightStoreCtx) {
+    throw new Error(
+      `useTwilightStoreApi must be used within TwilightStoreProvider`
+    );
+  }
+
+  return twilightStoreCtx;
+};

--- a/lib/twilight/denoms.ts
+++ b/lib/twilight/denoms.ts
@@ -64,6 +64,7 @@ export default class BTC {
   }
 
   static format(value: Big, unit?: BTCDenoms) {
+    let result: string;
     switch (unit) {
       case "sats":
         return value.toFixed(0).replace(/\.?0+$/, "");
@@ -74,5 +75,6 @@ export default class BTC {
       default:
         return value.toString();
     }
+    return result === "-0" ? "0" : result;
   }
 }

--- a/lib/utils/masterAccountQueue.ts
+++ b/lib/utils/masterAccountQueue.ts
@@ -1,0 +1,90 @@
+/**
+ * MasterAccountQueue — serialises every operation that reads or writes the
+ * master trading account UTXO.
+ *
+ * Because the ZKOS UTXO store is updated asynchronously (via a block-event
+ * oracle subscriber), two concurrent operations that both try to spend the
+ * same master-account UTXO will result in a double-spend rejection or
+ * corrupted local state.  By running all such operations one at a time
+ * through this queue we guarantee that each task starts with the latest
+ * on-chain UTXO.
+ *
+ * Usage:
+ *   import { masterAccountQueue } from "@/lib/utils/masterAccountQueue";
+ *
+ *   const result = await masterAccountQueue.enqueue(async () => {
+ *     // read fresh state, broadcast tx, wait for UTXO update, mutate store
+ *     return { ... };
+ *   });
+ *
+ * Rules for tasks:
+ *   - NEVER read tradingAccount from a React closure.  Instead read it from
+ *     the StoreApi passed via useTwilightStoreApi() and captured before
+ *     calling enqueue:
+ *       const storeApi = useTwilightStoreApi();
+ *       masterAccountQueue.enqueue(() => {
+ *         const ta = storeApi.getState().zk.zkAccounts.find(a => a.tag === "main");
+ *       });
+ *   - The task MUST call waitForUtxoUpdate() after every broadcastTradingTx
+ *     call so the on-chain UTXO store is consistent before the next task runs.
+ *   - Tasks time out after TASK_TIMEOUT_MS and the queue advances regardless.
+ */
+
+const TASK_TIMEOUT_MS = 60_000;
+
+type QueueEntry<T> = {
+  task: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+};
+
+class MasterAccountQueue {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly queue: QueueEntry<any>[] = [];
+  private _busy = false;
+
+  /** True while a task is executing. */
+  get busy(): boolean {
+    return this._busy;
+  }
+
+  /** Number of tasks waiting to run (does not include the running task). */
+  get pending(): number {
+    return this.queue.length;
+  }
+
+  /**
+   * Add a task to the queue.  Returns a Promise that resolves/rejects with
+   * the task's return value once the task has been executed.
+   */
+  enqueue<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({ task, resolve, reject });
+      this.advance();
+    });
+  }
+
+  private advance(): void {
+    if (this._busy || this.queue.length === 0) return;
+
+    this._busy = true;
+    const entry = this.queue.shift()!;
+
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("MasterAccountQueue: task timed out")),
+        TASK_TIMEOUT_MS
+      )
+    );
+
+    Promise.race([entry.task(), timeout])
+      .then((result) => entry.resolve(result))
+      .catch((err) => entry.reject(err))
+      .finally(() => {
+        this._busy = false;
+        this.advance();
+      });
+  }
+}
+
+export const masterAccountQueue = new MasterAccountQueue();

--- a/lib/utils/waitForUtxoUpdate.ts
+++ b/lib/utils/waitForUtxoUpdate.ts
@@ -1,0 +1,80 @@
+import { queryUtxoForAddress } from "@/lib/api/zkos";
+import { UtxoData } from "@/lib/types";
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+
+type WaitResult =
+  | { success: true }
+  | { success: false; message: string };
+
+/**
+ * Polls queryUtxoForAddress until the UTXO for `address` has a different
+ * txid than `previousTxid`, indicating that the on-chain UTXO store has
+ * been updated after the most recent broadcastTradingTx call.
+ *
+ * We compare txids rather than output_index because output_index is just
+ * the position within a transaction (almost always 0 for single-output
+ * Dark transfers) and will be the same for the old and new UTXO.
+ * txid is the unique transaction hash and changes with every new broadcast.
+ *
+ * Typical usage — inside a masterAccountQueue task, after broadcastTradingTx:
+ *
+ *   const utxo = await queryUtxoForAddress(masterAccount.address);
+ *   const previousTxid = hasUtxoData(utxo) ? serializeTxid(utxo.txid) : "";
+ *
+ *   await broadcastTradingTx(txHex);
+ *
+ *   const waited = await waitForUtxoUpdate(masterAccount.address, previousTxid);
+ *   if (!waited.success) { ... handle timeout ... }
+ */
+export async function waitForUtxoUpdate(
+  address: string,
+  previousTxid: string,
+  options?: { timeoutMs?: number; pollIntervalMs?: number }
+): Promise<WaitResult> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const pollIntervalMs = options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const result = await queryUtxoForAddress(address);
+
+    if (hasUtxoData(result)) {
+      const currentTxid = serializeTxid(result.txid);
+      if (currentTxid !== previousTxid) {
+        return { success: true };
+      }
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  return {
+    success: false,
+    message: `UTXO for address ${address.slice(0, 12)}… did not update within ${timeoutMs}ms`,
+  };
+}
+
+/**
+ * Serialise a txid byte-array to a stable string for comparison.
+ * JSON.stringify([1,2,3]) === JSON.stringify([1,2,3]) always holds,
+ * unlike referential equality on arrays.
+ */
+export function serializeTxid(txid: number[]): string {
+  return JSON.stringify(txid);
+}
+
+/**
+ * Type-guard: checks whether a queryUtxoForAddress result contains real
+ * UtxoData (vs the empty Record<string, never> returned on failure).
+ */
+export function hasUtxoData(
+  result: Record<string, never> | UtxoData
+): result is UtxoData {
+  return Object.hasOwn(result, "txid");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/lib/zk/account.ts
+++ b/lib/zk/account.ts
@@ -288,12 +288,34 @@ export class ZkPrivateAccount {
       };
     }
 
-    const tradingTxRes = JSON.parse(tradingTxResString);
-
-    if (Object.hasOwn(tradingTxRes, "error")) {
+    // The ZKOS server sometimes returns a raw non-JSON error string such as
+    // "{ Error: ... }" which JSON.parse cannot handle.  Parse defensively.
+    let tradingTxRes: Record<string, unknown>;
+    try {
+      tradingTxRes = JSON.parse(tradingTxResString);
+    } catch {
       return {
         success: false,
-        message: "Error",
+        message: `txCommit error: ${tradingTxResString}`,
+      };
+    }
+
+    // The server uses both "error" and "Error" as keys depending on context.
+    if (
+      Object.hasOwn(tradingTxRes, "error") ||
+      Object.hasOwn(tradingTxRes, "Error")
+    ) {
+      const detail = tradingTxRes.error ?? tradingTxRes.Error;
+      return {
+        success: false,
+        message: `txCommit error: ${String(detail)}`,
+      };
+    }
+
+    if (typeof tradingTxRes.txHash !== "string") {
+      return {
+        success: false,
+        message: `txCommit returned unexpected format: ${tradingTxResString}`,
       };
     }
 


### PR DESCRIPTION
…ns and display bugs

- Add MasterAccountQueue (FIFO promise queue) to prevent concurrent master account UTXO double-spends during order placement and background settlement
- Add waitForUtxoUpdate polling utility to bridge async ZKOS UTXO confirmation gap before the next queue task reads fresh state
- Expose useTwilightStoreApi to give queue tasks stale-closure-free access to Zustand state at execution time
- Exclude master account (tag==="main") from useSyncBalance background poller to prevent mid-flight UTXO overwrites
- Fix useSyncTrades to schedule at most one master-account cleanup per poll cycle, preventing multi-settlement UTXO double-spend races
- Fix handleSettleOrder passing stale pre-PnL balance to cleanupTradeOrder; now uses chain-verified newAccountBalance
- Fix handleCancelOrder: remove redundant getZkAccountBalance decrypt call (pending limit orders have unchanged value; ZkPrivateAccount.create fetches fresh UTXO independently)
- Fix false failure toast in details.client when useSyncTrades settles a trade before the foreground action completes
- Fix stale chainWallet closure in cleanupTradeOrder useCallback dependency array
- Improve txCommit error handling to parse malformed ZKOS server error strings