### PR TITLE
Funding History Integration

### DIFF
--- a/app/_components/trade/details/tables/order-history/columns.tsx
+++ b/app/_components/trade/details/tables/order-history/columns.tsx
@@ -1,6 +1,7 @@
+import Button from "@/components/button";
 import { Text } from "@/components/typography";
 import cn from "@/lib/cn";
-import { capitaliseFirstLetter, truncateHash } from "@/lib/helpers";
+import { capitaliseFirstLetter, formatSatsMBtc, truncateHash } from "@/lib/helpers";
 import { toast } from "@/lib/hooks/useToast";
 import BTC from "@/lib/twilight/denoms";
 import { TradeOrder } from "@/lib/types";
@@ -14,6 +15,7 @@ import { PnlCell, PnlHeader } from "@/lib/components/pnl-display";
 interface OrderHistoryTableMeta {
   getCurrentPrice: () => number;
   getBtcPriceUsd: () => number;
+  openFundingDialog: (trade: TradeOrder) => void;
 }
 
 // Update the interface to remove currentPrice and privateKey from row data
@@ -230,9 +232,10 @@ export const orderHistoryColumns: ColumnDef<MyTradeOrder, any>[] = [
   },
   {
     accessorKey: "funding",
-    header: "Funding (BTC)",
+    header: "Funding (mBTC)",
     cell: (row) => {
       const trade = row.row.original;
+      const meta = row.table.options.meta as OrderHistoryTableMeta;
 
       const pnl =
         trade.orderStatus === "LIQUIDATE"
@@ -249,23 +252,36 @@ export const orderHistoryColumns: ColumnDef<MyTradeOrder, any>[] = [
                 pnl
             );
 
-      const fundingBTC = new BTC("sats", Big(funding)).convert("BTC");
-
       return (
-        <span
-          className={cn(
-            "font-medium",
-            funding > 0 ? "text-green-medium" : funding < 0 ? "text-red" : ""
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              "font-medium",
+              funding > 0 ? "text-green-medium" : funding < 0 ? "text-red" : ""
+            )}
+          >
+            {formatSatsMBtc(funding)}
+          </span>
+          {(trade.orderStatus === "SETTLED" || trade.orderStatus === "LIQUIDATE") && (
+            <Button
+              variant="ui"
+              size="small"
+              onClick={(e) => {
+                e.preventDefault();
+                meta.openFundingDialog(trade);
+              }}
+              className="px-2 py-0.5 text-xs"
+            >
+              Details
+            </Button>
           )}
-        >
-          {BTC.format(fundingBTC, "BTC")}
-        </span>
+        </div>
       );
     },
   },
   {
     accessorKey: "feeFilled",
-    header: "Fee (BTC)",
+    header: "Fee (mBTC)",
     cell: (row) => {
       const trade = row.row.original;
 
@@ -282,7 +298,7 @@ export const orderHistoryColumns: ColumnDef<MyTradeOrder, any>[] = [
 
       return (
         <span className="font-medium">
-          {BTC.format(new BTC("sats", Big(fee)).convert("BTC"), "BTC")}
+          {formatSatsMBtc(fee)}
         </span>
       );
     },

--- a/app/_components/trade/details/tables/order-history/data-table.tsx
+++ b/app/_components/trade/details/tables/order-history/data-table.tsx
@@ -18,6 +18,7 @@ interface DataTableProps<TData, TValue> {
   data: TData[];
   getCurrentPrice: () => number;
   getBtcPriceUsd: () => number;
+  openFundingDialog: (trade: import("@/lib/types").TradeOrder) => void;
 }
 
 export function OrderHistoryDataTable<TData, TValue>({
@@ -25,6 +26,7 @@ export function OrderHistoryDataTable<TData, TValue>({
   data,
   getCurrentPrice,
   getBtcPriceUsd,
+  openFundingDialog,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([
     { id: "date", desc: true },
@@ -34,6 +36,7 @@ export function OrderHistoryDataTable<TData, TValue>({
   const tableMeta: OrderHistoryTableMeta = {
     getCurrentPrice,
     getBtcPriceUsd,
+    openFundingDialog,
   };
 
   const table = useReactTable({

--- a/app/_components/trade/details/tables/order-history/order-history-table.client.tsx
+++ b/app/_components/trade/details/tables/order-history/order-history-table.client.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import React, { useSyncExternalStore } from 'react';
+import React, { useCallback, useState, useSyncExternalStore } from 'react';
 import { OrderHistoryDataTable } from './data-table';
 import { orderHistoryColumns } from './columns';
 import { TradeOrder } from '@/lib/types';
 import { usePriceFeed } from '@/lib/providers/feed';
 import { useSessionStore } from '@/lib/providers/session';
+import FundingHistoryDialog from '@/components/funding-history-dialog';
 
 interface OrderHistoryTableProps {
   data: TradeOrder[];
@@ -17,13 +18,32 @@ const OrderHistoryTable = React.memo(function OrderHistoryTable({ data }: OrderH
   const currentPrice = useSyncExternalStore(subscribe, getCurrentPrice, () => 0);
   const getBtcPriceUsd = () => currentPrice || storedBtcPrice;
 
+  const [fundingDialogTrade, setFundingDialogTrade] = useState<TradeOrder | null>(null);
+  const [isFundingDialogOpen, setIsFundingDialogOpen] = useState(false);
+
+  const openFundingDialog = useCallback((trade: TradeOrder) => {
+    setFundingDialogTrade(trade);
+    setIsFundingDialogOpen(true);
+  }, []);
+
   return (
-    <OrderHistoryDataTable
-      columns={orderHistoryColumns}
-      data={data}
-      getCurrentPrice={getCurrentPrice}
-      getBtcPriceUsd={getBtcPriceUsd}
-    />
+    <>
+      <OrderHistoryDataTable
+        columns={orderHistoryColumns}
+        data={data}
+        getCurrentPrice={getCurrentPrice}
+        getBtcPriceUsd={getBtcPriceUsd}
+        openFundingDialog={openFundingDialog}
+      />
+      <FundingHistoryDialog
+        trade={fundingDialogTrade}
+        open={isFundingDialogOpen}
+        onOpenChange={(open) => {
+          setIsFundingDialogOpen(open);
+          if (!open) setFundingDialogTrade(null);
+        }}
+      />
+    </>
   );
 });
 

--- a/app/_components/trade/details/tables/positions/columns.tsx
+++ b/app/_components/trade/details/tables/positions/columns.tsx
@@ -1,6 +1,6 @@
 import Button from '@/components/button';
 import cn from '@/lib/cn';
-import { capitaliseFirstLetter } from '@/lib/helpers';
+import { capitaliseFirstLetter, formatSatsMBtc } from '@/lib/helpers';
 import BTC from '@/lib/twilight/denoms';
 import { TradeOrder } from '@/lib/types';
 import { ColumnDef } from '@tanstack/react-table';
@@ -16,6 +16,7 @@ interface PositionsTableMeta {
   settleMarketOrder: (trade: TradeOrder, currentPrice: number) => Promise<void>;
   isSettlingOrder: (uuid: string) => boolean;
   openLimitDialog: (account: string) => void;
+  openFundingDialog: (trade: TradeOrder) => void;
 }
 
 // Update the interface to remove currentPrice and privateKey from row data
@@ -123,33 +124,44 @@ export const positionsColumns: ColumnDef<MyTradeOrder, any>[] = [
   },
   {
     accessorKey: "funding",
-    header: "Funding (BTC)",
+    header: "Funding (mBTC)",
     cell: (row) => {
       const trade = row.row.original;
+      const meta = row.table.options.meta as PositionsTableMeta;
 
       const pnl = trade.unrealizedPnl || 0;
       const funding = trade.fundingApplied != null
         ? Number(trade.fundingApplied)
         : Math.round(trade.initialMargin - trade.availableMargin - trade.feeFilled + pnl);
 
-      const fundingBTC = new BTC("sats", Big(funding))
-        .convert("BTC")
-
       return (
-        <span className={cn("font-medium",
-          funding > 0 ? "text-green-medium" :
-            funding < 0 ? "text-red" :
-              ""
-        )}>
-          {BTC.format(fundingBTC, "BTC")}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className={cn("font-medium",
+            funding > 0 ? "text-green-medium" :
+              funding < 0 ? "text-red" :
+                ""
+          )}>
+            {formatSatsMBtc(funding)}
+          </span>
+          <Button
+            variant="ui"
+            size="small"
+            onClick={(e) => {
+              e.preventDefault();
+              meta.openFundingDialog(trade);
+            }}
+            className="px-2 py-0.5 text-xs"
+          >
+            Details
+          </Button>
+        </div>
       );
     },
   },
   {
     accessorKey: "feeFilled",
-    header: "Fee (BTC)",
-    accessorFn: (row) => BTC.format(new BTC("sats", Big(row.feeFilled)).convert("BTC"), "BTC")
+    header: "Fee (mBTC)",
+    accessorFn: (row) => formatSatsMBtc(row.feeFilled)
   },
   {
     accessorKey: "positionType",

--- a/app/_components/trade/details/tables/positions/data-table.tsx
+++ b/app/_components/trade/details/tables/positions/data-table.tsx
@@ -19,6 +19,7 @@ interface DataTableProps<TData, TValue> {
   getCurrentPrice: () => number;
   getBtcPriceUsd: () => number;
   openLimitDialog: (account: string) => void;
+  openFundingDialog: (trade: TradeOrder) => void;
   settleMarketOrder: (trade: TradeOrder, currentPrice: number) => Promise<void>;
   isSettlingOrder: (uuid: string) => boolean;
 }
@@ -29,6 +30,7 @@ export function PositionsDataTable<TData, TValue>({
   getCurrentPrice,
   getBtcPriceUsd,
   openLimitDialog,
+  openFundingDialog,
   settleMarketOrder,
   isSettlingOrder
 }: DataTableProps<TData, TValue>) {
@@ -43,6 +45,7 @@ export function PositionsDataTable<TData, TValue>({
     getCurrentPrice,
     getBtcPriceUsd,
     openLimitDialog,
+    openFundingDialog,
     settleMarketOrder,
     isSettlingOrder
   };

--- a/app/_components/trade/details/tables/positions/positions-table.client.tsx
+++ b/app/_components/trade/details/tables/positions/positions-table.client.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import React, { useSyncExternalStore } from 'react';
+import React, { useCallback, useState, useSyncExternalStore } from 'react';
 import { PositionsDataTable } from './data-table';
 import { positionsColumns } from './columns';
 import { TradeOrder } from '@/lib/types';
 import { useLimitDialog } from '@/lib/providers/limit-dialogs';
 import { usePriceFeed } from '@/lib/providers/feed';
 import { useSessionStore } from '@/lib/providers/session';
+import FundingHistoryDialog from '@/components/funding-history-dialog';
 
 interface PositionsTableProps {
   data: TradeOrder[];
@@ -18,22 +19,40 @@ const PositionsTable = React.memo(function PositionsTable({ data, settleMarketOr
   const { openLimitDialog } = useLimitDialog();
   const storedBtcPrice = useSessionStore((state) => state.price.btcPrice);
 
+  const [fundingDialogTrade, setFundingDialogTrade] = useState<TradeOrder | null>(null);
+  const [isFundingDialogOpen, setIsFundingDialogOpen] = useState(false);
+
+  const openFundingDialog = useCallback((trade: TradeOrder) => {
+    setFundingDialogTrade(trade);
+    setIsFundingDialogOpen(true);
+  }, []);
+
   const { getCurrentPrice, subscribe } = usePriceFeed()
   // Subscribe to price updates so mark price / UPNL columns refresh
   const currentPrice = useSyncExternalStore(subscribe, getCurrentPrice, () => 0);
   const getBtcPriceUsd = () => currentPrice || storedBtcPrice;
 
   return (
-    <PositionsDataTable
-      columns={positionsColumns}
-      data={data}
-      getCurrentPrice={getCurrentPrice}
-      getBtcPriceUsd={getBtcPriceUsd}
-      settleMarketOrder={settleMarketOrder}
-      isSettlingOrder={isSettlingOrder}
-      openLimitDialog={openLimitDialog}
-    />
-
+    <>
+      <PositionsDataTable
+        columns={positionsColumns}
+        data={data}
+        getCurrentPrice={getCurrentPrice}
+        getBtcPriceUsd={getBtcPriceUsd}
+        settleMarketOrder={settleMarketOrder}
+        isSettlingOrder={isSettlingOrder}
+        openLimitDialog={openLimitDialog}
+        openFundingDialog={openFundingDialog}
+      />
+      <FundingHistoryDialog
+        trade={fundingDialogTrade}
+        open={isFundingDialogOpen}
+        onOpenChange={(open) => {
+          setIsFundingDialogOpen(open);
+          if (!open) setFundingDialogTrade(null);
+        }}
+      />
+    </>
   );
 });
 

--- a/app/_components/trade/details/tables/trader-history/columns.tsx
+++ b/app/_components/trade/details/tables/trader-history/columns.tsx
@@ -1,5 +1,6 @@
+import Button from '@/components/button';
 import cn from '@/lib/cn';
-import { capitaliseFirstLetter, truncateHash } from '@/lib/helpers';
+import { capitaliseFirstLetter, formatSatsMBtc, truncateHash } from '@/lib/helpers';
 import { toast } from '@/lib/hooks/useToast';
 import BTC from '@/lib/twilight/denoms';
 import { TradeOrder } from '@/lib/types';
@@ -12,6 +13,7 @@ import { PnlCell, PnlHeader } from '@/lib/components/pnl-display';
 interface TraderHistoryTableMeta {
   getCurrentPrice: () => number;
   getBtcPriceUsd: () => number;
+  openFundingDialog: (trade: TradeOrder) => void;
 }
 
 // Update the interface to remove currentPrice and privateKey from row data
@@ -142,9 +144,10 @@ export const traderHistoryColumns: ColumnDef<MyTradeOrder, any>[] = [
   },
   {
     accessorKey: "funding",
-    header: "Funding (BTC)",
+    header: "Funding (mBTC)",
     cell: (row) => {
       const trade = row.row.original;
+      const meta = row.table.options.meta as TraderHistoryTableMeta;
 
       const pnl = trade.orderStatus === "LIQUIDATE"
         ? -trade.initialMargin
@@ -153,23 +156,35 @@ export const traderHistoryColumns: ColumnDef<MyTradeOrder, any>[] = [
         ? Number(trade.fundingApplied)
         : Math.round(trade.initialMargin - trade.availableMargin - trade.feeFilled - trade.feeSettled + pnl);
 
-      const fundingBTC = new BTC("sats", Big(funding))
-        .convert("BTC")
-
       return (
-        <span className={cn("font-medium",
-          funding > 0 ? "text-green-medium" :
-            funding < 0 ? "text-red" :
-              ""
-        )}>
-          {BTC.format(fundingBTC, "BTC")}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className={cn("font-medium",
+            funding > 0 ? "text-green-medium" :
+              funding < 0 ? "text-red" :
+                ""
+          )}>
+            {formatSatsMBtc(funding)}
+          </span>
+          {(trade.orderStatus === "SETTLED" || trade.orderStatus === "LIQUIDATE") && (
+            <Button
+              variant="ui"
+              size="small"
+              onClick={(e) => {
+                e.preventDefault();
+                meta.openFundingDialog(trade);
+              }}
+              className="px-2 py-0.5 text-xs"
+            >
+              Details
+            </Button>
+          )}
+        </div>
       );
     },
   },
   {
     accessorKey: "feeFilled",
-    header: "Fee (BTC)",
+    header: "Fee (mBTC)",
     cell: (row) => {
       const trade = row.row.original;
 
@@ -177,7 +192,7 @@ export const traderHistoryColumns: ColumnDef<MyTradeOrder, any>[] = [
 
       return (
         <span className="font-medium">
-          {BTC.format(new BTC("sats", Big(fee)).convert("BTC"), "BTC")}
+          {formatSatsMBtc(fee)}
         </span>
       );
     }

--- a/app/_components/trade/details/tables/trader-history/data-table.tsx
+++ b/app/_components/trade/details/tables/trader-history/data-table.tsx
@@ -17,6 +17,7 @@ interface DataTableProps<TData, TValue> {
   data: TData[];
   getCurrentPrice: () => number;
   getBtcPriceUsd: () => number;
+  openFundingDialog: (trade: import("@/lib/types").TradeOrder) => void;
 }
 
 export function TraderHistoryDataTable<TData, TValue>({
@@ -24,6 +25,7 @@ export function TraderHistoryDataTable<TData, TValue>({
   data,
   getCurrentPrice,
   getBtcPriceUsd,
+  openFundingDialog,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([
     { id: "date", desc: true },
@@ -33,6 +35,7 @@ export function TraderHistoryDataTable<TData, TValue>({
   const tableMeta: TraderHistoryTableMeta = {
     getCurrentPrice,
     getBtcPriceUsd,
+    openFundingDialog,
   };
 
   const table = useReactTable({

--- a/app/_components/trade/details/tables/trader-history/trader-history-table.client.tsx
+++ b/app/_components/trade/details/tables/trader-history/trader-history-table.client.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import React, { useSyncExternalStore } from 'react';
+import React, { useCallback, useState, useSyncExternalStore } from 'react';
 import { TraderHistoryDataTable } from './data-table';
 import { traderHistoryColumns } from './columns';
 import { TradeOrder } from '@/lib/types';
 import { usePriceFeed } from '@/lib/providers/feed';
 import { useSessionStore } from '@/lib/providers/session';
+import FundingHistoryDialog from '@/components/funding-history-dialog';
 
 interface TraderHistoryTableProps {
   data: TradeOrder[];
@@ -17,13 +18,32 @@ const TraderHistoryTable = React.memo(function TraderHistoryTable({ data }: Trad
   const currentPrice = useSyncExternalStore(subscribe, getCurrentPrice, () => 0);
   const getBtcPriceUsd = () => currentPrice || storedBtcPrice;
 
+  const [fundingDialogTrade, setFundingDialogTrade] = useState<TradeOrder | null>(null);
+  const [isFundingDialogOpen, setIsFundingDialogOpen] = useState(false);
+
+  const openFundingDialog = useCallback((trade: TradeOrder) => {
+    setFundingDialogTrade(trade);
+    setIsFundingDialogOpen(true);
+  }, []);
+
   return (
-    <TraderHistoryDataTable
-      columns={traderHistoryColumns}
-      data={data}
-      getCurrentPrice={getCurrentPrice}
-      getBtcPriceUsd={getBtcPriceUsd}
-    />
+    <>
+      <TraderHistoryDataTable
+        columns={traderHistoryColumns}
+        data={data}
+        getCurrentPrice={getCurrentPrice}
+        getBtcPriceUsd={getBtcPriceUsd}
+        openFundingDialog={openFundingDialog}
+      />
+      <FundingHistoryDialog
+        trade={fundingDialogTrade}
+        open={isFundingDialogOpen}
+        onOpenChange={(open) => {
+          setIsFundingDialogOpen(open);
+          if (!open) setFundingDialogTrade(null);
+        }}
+      />
+    </>
   );
 });
 

--- a/app/_components/trade/orderbook/my-trades.client.tsx
+++ b/app/_components/trade/orderbook/my-trades.client.tsx
@@ -35,6 +35,7 @@ import { broadcastTradingTx } from "@/lib/api/zkos";
 import { useWallet } from "@cosmos-kit/react-lite";
 import { twilightproject } from "twilightjs";
 import Long from "long";
+import FundingHistoryDialog from "@/components/funding-history-dialog";
 
 const OrderMyTrades = () => {
   const { toast } = useToast();
@@ -57,6 +58,15 @@ const OrderMyTrades = () => {
   const tradeOrders = useTwilightStore((state) => state.trade.trades);
 
   const removeTrade = useTwilightStore((state) => state.trade.removeTrade);
+
+  const [fundingDialogTrade, setFundingDialogTrade] =
+    React.useState<TradeOrder | null>(null);
+  const [isFundingDialogOpen, setIsFundingDialogOpen] = React.useState(false);
+
+  const openFundingDialog = useCallback((trade: TradeOrder) => {
+    setFundingDialogTrade(trade);
+    setIsFundingDialogOpen(true);
+  }, []);
 
   const { mainWallet } = useWallet();
 
@@ -838,12 +848,21 @@ const OrderMyTrades = () => {
         ...trade,
         onSettle: () => handleSettleOrder(trade),
         onCancel: () => handleCancelOrder(trade),
+        openFundingDialog,
       }));
-  }, [tradeOrders, handleSettleOrder, handleCancelOrder]);
+  }, [tradeOrders, handleSettleOrder, handleCancelOrder, openFundingDialog]);
 
   return (
     <div className="w-full px-3">
       <MyTradesDataTable columns={enhancedColumns} data={tableData} />
+      <FundingHistoryDialog
+        trade={fundingDialogTrade}
+        open={isFundingDialogOpen}
+        onOpenChange={(open) => {
+          setIsFundingDialogOpen(open);
+          if (!open) setFundingDialogTrade(null);
+        }}
+      />
     </div>
   );
 };

--- a/app/_components/trade/orderbook/my-trades/columns.tsx
+++ b/app/_components/trade/orderbook/my-trades/columns.tsx
@@ -2,6 +2,7 @@
 
 import Button from "@/components/button";
 import cn from "@/lib/cn";
+import { formatSatsMBtc } from "@/lib/helpers";
 import BTC from "@/lib/twilight/denoms";
 import { TradeOrder } from "@/lib/types";
 import { ColumnDef } from "@tanstack/react-table";
@@ -11,6 +12,7 @@ import dayjs from 'dayjs';
 interface MyTradeOrder extends TradeOrder {
   onSettle: (trade: TradeOrder) => void;
   onCancel: (trade: TradeOrder) => void;
+  openFundingDialog?: (trade: TradeOrder) => void;
   currentPrice?: number;
   calculatedUnrealizedPnl?: number;
 }
@@ -188,7 +190,7 @@ export const myTradesColumns: ColumnDef<MyTradeOrder, any>[] = [
   },
   {
     accessorKey: "funding",
-    header: "Funding (BTC)",
+    header: "Funding (mBTC)",
     cell: (row) => {
       const trade = row.row.original;
 
@@ -199,24 +201,36 @@ export const myTradesColumns: ColumnDef<MyTradeOrder, any>[] = [
       const fee = trade.feeFilled;
 
       const funding = Math.round(trade.initialMargin - trade.availableMargin - fee);
-      const fundingBTC = new BTC("sats", Big(funding))
-        .convert("BTC")
 
       return (
-        <span className={cn("font-medium",
-          funding > 0 ? "text-green-medium" :
-            funding < 0 ? "text-red" :
-              ""
-        )}>
-          {BTC.format(fundingBTC, "BTC")} BTC
-        </span>
-
+        <div className="flex items-center gap-2">
+          <span className={cn("font-medium",
+            funding > 0 ? "text-green-medium" :
+              funding < 0 ? "text-red" :
+                ""
+          )}>
+            {formatSatsMBtc(funding)}
+          </span>
+          {trade.openFundingDialog && (
+            <Button
+              variant="ui"
+              size="small"
+              onClick={(e) => {
+                e.preventDefault();
+                trade.openFundingDialog?.(trade);
+              }}
+              className="px-2 py-0.5 text-xs"
+            >
+              Details
+            </Button>
+          )}
+        </div>
       );
     },
   },
   {
     accessorKey: "fee",
-    header: "Fee (BTC)",
+    header: "Fee (mBTC)",
     cell: (row) => {
       const fee = row.getValue() as number;
       const trade = row.row.original;
@@ -227,7 +241,7 @@ export const myTradesColumns: ColumnDef<MyTradeOrder, any>[] = [
 
       return (
         <span className="font-medium">
-          {BTC.format(new BTC("sats", Big(fee)).convert("BTC"), "BTC")}
+          {formatSatsMBtc(fee)}
         </span>
       );
     },

--- a/components/funding-history-dialog.tsx
+++ b/components/funding-history-dialog.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Dialog, DialogContent, DialogTitle } from "./dialog";
+import Button from "./button";
+import { useSessionStore } from "@/lib/providers/session";
+import { useTwilightStore } from "@/lib/providers/store";
+import { createQueryTradeOrderMsg } from "@/lib/twilight/zkos";
+import { queryOrderFundingHistory } from "@/lib/api/relayer";
+import { TradeOrder } from "@/lib/types";
+import Big from "big.js";
+import dayjs from "dayjs";
+import { Loader2, RefreshCw } from "lucide-react";
+import cn from "@/lib/cn";
+import { capitaliseFirstLetter, formatSatsMBtc } from "@/lib/helpers";
+
+type Props = {
+  trade: TradeOrder | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+function FundingHistoryDialog({ trade, open, onOpenChange }: Props) {
+  const privateKey = useSessionStore((state) => state.privateKey);
+  const updateTradeFundingHistory = useTwilightStore(
+    (state) => state.trade.updateTradeFundingHistory
+  );
+  const updateTradeHistoryFundingHistory = useTwilightStore(
+    (state) => state.trade_history.updateTradeFundingHistory
+  );
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [displayHistory, setDisplayHistory] = useState<
+    NonNullable<TradeOrder["fundingHistory"]>
+  >([]);
+
+  const cachedHistory = trade?.fundingHistory;
+
+  const fetchFundingHistory = useCallback(async (forceRefresh = false) => {
+    if (!trade || !privateKey) return;
+
+    const useCached =
+      !forceRefresh && cachedHistory && cachedHistory.length > 0;
+
+    if (useCached) {
+      setDisplayHistory(cachedHistory);
+      setError(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const msg = await createQueryTradeOrderMsg({
+        address: trade.accountAddress,
+        orderStatus: trade.orderStatus,
+        signature: privateKey,
+      });
+
+      const history = await queryOrderFundingHistory(msg);
+
+      if (history === null) {
+        setError("Failed to fetch funding history");
+        return;
+      }
+
+      setDisplayHistory(history);
+      updateTradeFundingHistory(trade.uuid, history);
+      updateTradeHistoryFundingHistory(trade.uuid, history);
+    } catch (err) {
+      console.error("FundingHistoryDialog fetch error:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to fetch funding history"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    trade,
+    privateKey,
+    cachedHistory,
+    updateTradeFundingHistory,
+    updateTradeHistoryFundingHistory,
+  ]);
+
+  useEffect(() => {
+    if (!open || !trade) return;
+    if (cachedHistory && cachedHistory.length > 0) {
+      setDisplayHistory(cachedHistory);
+    }
+    fetchFundingHistory(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, trade?.uuid]);
+
+  const totalPaymentSats = displayHistory.reduce(
+    (sum, e) => sum + Big(e.payment).toNumber(),
+    0
+  );
+
+  if (!trade) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogTitle>Funding History</DialogTitle>
+        <div className="flex flex-col gap-4">
+          {!privateKey ? (
+            <p className="text-sm text-muted-foreground">
+              Connect your wallet to view funding history.
+            </p>
+          ) : isLoading && displayHistory.length === 0 ? (
+            <div className="flex items-center justify-center gap-2 py-8">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              <span className="text-sm">Loading funding history...</span>
+            </div>
+          ) : error && displayHistory.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-6">
+              <p className="text-sm text-red">{error}</p>
+              <Button
+                variant="ui"
+                size="small"
+                onClick={() => fetchFundingHistory(true)}
+              >
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Retry
+              </Button>
+            </div>
+          ) : displayHistory.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              No funding was applied to this order.
+            </p>
+          ) : (
+            <>
+              <div className="max-h-[280px] overflow-auto rounded border">
+                <table className="w-full text-sm">
+                  <thead className="sticky top-0 bg-muted/50">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-medium">
+                        Time
+                      </th>
+                      <th className="px-3 py-2 text-left font-medium">
+                        Side
+                      </th>
+                      <th className="px-3 py-2 text-right font-medium">
+                        Payment (mBTC)
+                      </th>
+                      <th className="px-3 py-2 text-right font-medium">
+                        Rate
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {displayHistory.map((entry, i) => (
+                      <tr
+                        key={`${entry.time}-${i}`}
+                        className="border-t border-border/50"
+                      >
+                        <td className="px-3 py-2">
+                          {dayjs(entry.time).format("DD/MM/YYYY HH:mm:ss")}
+                        </td>
+                        <td className="px-3 py-2">
+                          <span
+                            className={cn(
+                              "rounded px-2 py-0.5 text-xs font-medium",
+                              entry.position_side === "LONG"
+                                ? "bg-green-medium/10 text-green-medium"
+                                : "bg-red/10 text-red"
+                            )}
+                          >
+                            {capitaliseFirstLetter(entry.position_side)}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-right font-medium">
+                          {formatSatsMBtc(Big(entry.payment).toNumber())}
+                        </td>
+                        <td className="px-3 py-2 text-right">
+                          {parseFloat(entry.funding_rate || "0").toFixed(5)}%
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="flex items-center justify-between border-t pt-3">
+                <span className="text-sm font-medium">Total funding applied</span>
+                <span
+                  className={cn(
+                    "font-medium",
+                    totalPaymentSats > 0
+                      ? "text-green-medium"
+                      : totalPaymentSats < 0
+                        ? "text-red"
+                        : ""
+                  )}
+                >
+                  {formatSatsMBtc(totalPaymentSats)} mBTC
+                </span>
+              </div>
+              <Button
+                variant="ui"
+                size="small"
+                onClick={() => fetchFundingHistory(true)}
+                disabled={isLoading}
+                className="self-end"
+              >
+                {isLoading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                )}
+                Refresh
+              </Button>
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default FundingHistoryDialog;

--- a/lib/api/relayer.ts
+++ b/lib/api/relayer.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
 import wfetch from "../http";
 import { createCancelTraderOrderMsg } from "../twilight/zkos";
-import { QueryLendOrderData } from "../types";
+import { FundingHistoryEntry, QueryLendOrderData } from "../types";
 
 const RELAYER_PUBLIC_URL = process.env
   .NEXT_PUBLIC_TWILIGHT_PRICE_REST as string;
@@ -132,4 +132,36 @@ async function queryTradeOrder(msg: string) {
   };
 }
 
-export { queryLendOrder, queryTradeOrder, cancelTradeOrder };
+async function queryOrderFundingHistory(msg: string) {
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    method: "order_funding_history",
+    params: {
+      data: msg,
+    },
+    id: 1,
+  });
+
+  const { success, data, error } = await wfetch(RELAYER_PUBLIC_URL, {
+    headers: {
+      "date-time": dayjs().unix().toString(),
+      "Content-Type": "application/json",
+    },
+  })
+    .post({ body })
+    .json<Record<string, any>>();
+
+  if (!success) {
+    console.error("queryOrderFundingHistory error", error);
+    return null;
+  }
+
+  const result = data?.result;
+  if (!Array.isArray(result)) {
+    return [];
+  }
+
+  return result as FundingHistoryEntry[];
+}
+
+export { queryLendOrder, queryTradeOrder, cancelTradeOrder, queryOrderFundingHistory };

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -154,6 +154,17 @@ export function capitaliseFirstLetter(str: string) {
  * @param minLength - Minimum length before truncating (default: 16)
  * @returns The truncated hash or original if shorter than minLength
  */
+/**
+ * Formats sats as mBTC with up to 5 decimal places.
+ * Use for small amounts (funding, fees) where BTC.format's 2-decimal mBTC loses precision.
+ */
+export function formatSatsMBtc(sats: number): string {
+  if (!Number.isFinite(sats)) return "0";
+  const mBtc = sats / 100_000; // 1 mBTC = 100,000 sats
+  const s = mBtc.toFixed(5).replace(/\.?0+$/, "");
+  return s === "-0" ? "0" : s;
+}
+
 export function truncateHash(
   hash: string | null | undefined,
   startLength: number = 8,

--- a/lib/hooks/useFundingCycleTrigger.ts
+++ b/lib/hooks/useFundingCycleTrigger.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { getFundingRate } from "../api/rest";
+import dayjs from "dayjs";
+
+/**
+ * Independent funding cycle detector (Option A).
+ * Uses funding-rate API as source of truth, triggers funding history refresh
+ * when the clock crosses the next hourly boundary. Decoupled from the ticker.
+ */
+export function useFundingCycleTrigger() {
+  const queryClient = useQueryClient();
+  const lastTriggeredRef = useRef<number>(0);
+
+  const fundingQuery = useQuery({
+    queryKey: ["funding-rate"],
+    queryFn: async () => {
+      const fundingRes = await getFundingRate();
+      if (!fundingRes.success || fundingRes.error) {
+        throw new Error("Failed to fetch funding rate");
+      }
+      return fundingRes.data.result;
+    },
+    staleTime: 60_000,
+  });
+
+  const fundingTimestamp = fundingQuery.data?.timestamp;
+
+  useEffect(() => {
+    if (!fundingTimestamp) return;
+
+    const timer = setInterval(() => {
+      const now = dayjs();
+      const fundingTime = dayjs(fundingTimestamp);
+      const nextFunding = fundingTime.add(1, "hour");
+
+      if (now.isAfter(nextFunding) || now.isSame(nextFunding)) {
+        // Avoid double-triggering within the same cycle
+        const cycleKey = Math.floor(nextFunding.valueOf() / 3600000);
+        if (lastTriggeredRef.current === cycleKey) return;
+        lastTriggeredRef.current = cycleKey;
+
+        queryClient.invalidateQueries({ queryKey: ["funding-rate"] });
+        queryClient.invalidateQueries({ queryKey: ["funding-history-refresh"] });
+      }
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [fundingTimestamp, queryClient]);
+}

--- a/lib/hooks/useFundingHistoryRefresh.ts
+++ b/lib/hooks/useFundingHistoryRefresh.ts
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import { useTwilightStore } from "../providers/store";
+import { createQueryTradeOrderMsg } from "../twilight/zkos";
+import { useSessionStore } from "../providers/session";
+import { queryOrderFundingHistory } from "../api/relayer";
+import { useWallet } from "@cosmos-kit/react-lite";
+import { WalletStatus } from "@cosmos-kit/core";
+
+/**
+ * Fetches funding history for all FILLED trades when triggered by
+ * useFundingCycleTrigger or on mount. Stores results in Zustand (persisted).
+ */
+export function useFundingHistoryRefresh() {
+  const tradeOrders = useTwilightStore((state) => state.trade.trades);
+  const updateTradeFundingHistory = useTwilightStore(
+    (state) => state.trade.updateTradeFundingHistory
+  );
+  const updateTradeHistoryFundingHistory = useTwilightStore(
+    (state) => state.trade_history.updateTradeFundingHistory
+  );
+
+  const { status, mainWallet } = useWallet();
+  const twilightAddress = mainWallet?.getChainWallet("nyks")?.address;
+  const privateKey = useSessionStore((state) => state.privateKey);
+
+  const filledTrades = tradeOrders.filter((t) => t.orderStatus === "FILLED");
+  const hasFilledTrades = filledTrades.length > 0;
+  const isConnected = status === WalletStatus.Connected;
+
+  useQuery({
+    queryKey: ["funding-history-refresh", twilightAddress, filledTrades.length],
+    queryFn: async () => {
+      if (!privateKey || filledTrades.length === 0) return true;
+
+      for (const trade of filledTrades) {
+        try {
+          const msg = await createQueryTradeOrderMsg({
+            address: trade.accountAddress,
+            orderStatus: trade.orderStatus,
+            signature: privateKey,
+          });
+
+          const history = await queryOrderFundingHistory(msg);
+          if (history !== null) {
+            updateTradeFundingHistory(trade.uuid, history);
+            updateTradeHistoryFundingHistory(trade.uuid, history);
+          }
+        } catch (err) {
+          console.warn("useFundingHistoryRefresh: fetch failed for", trade.uuid, err);
+        }
+      }
+
+      return true;
+    },
+    enabled: isConnected && hasFilledTrades && !!privateKey,
+    refetchOnMount: true,
+    staleTime: 60_000,
+  });
+}

--- a/lib/providers/feed.tsx
+++ b/lib/providers/feed.tsx
@@ -2,6 +2,8 @@
 import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
 import { useReconcileOrphanedAccounts } from '../hooks/useReconcileOrphanedAccounts';
 import { useSyncTrades } from '../hooks/useSyncTrades';
+import { useFundingCycleTrigger } from '../hooks/useFundingCycleTrigger';
+import { useFundingHistoryRefresh } from '../hooks/useFundingHistoryRefresh';
 
 type PriceFeedProviderProps = {
   children: React.ReactNode;
@@ -97,5 +99,9 @@ const PriceFeed: React.FC<PriceFeedProviderProps> = ({ children }) => {
 const PriceFeedConsumers: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   useReconcileOrphanedAccounts();
   useSyncTrades();
+  useFundingCycleTrigger();
+  useFundingHistoryRefresh();
+  // useSyncBalance()
+
   return <>{children}</>;
 };

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -48,6 +48,17 @@ export const TradeOrderSchema = z.object({
     })
     .nullable(),
   fundingApplied: z.string().nullable(),
+  fundingHistory: z
+    .array(
+      z.object({
+        time: z.string(),
+        position_side: z.string(),
+        payment: z.string(),
+        funding_rate: z.string(),
+        order_id: z.string(),
+      })
+    )
+    .optional(),
 });
 
 export const LendOrderSchema = z.object({

--- a/lib/state/local/trade-history.ts
+++ b/lib/state/local/trade-history.ts
@@ -1,10 +1,11 @@
-import { TradeOrder } from "@/lib/types";
+import { FundingHistoryEntry, TradeOrder } from "@/lib/types";
 import { AccountSlices, StateImmerCreator } from "../utils";
 
 export interface TradeHistorySlice {
   trades: TradeOrder[];
   addTrade: (tradeOrder: TradeOrder) => void;
   removeTrade: (tradeOrder: TradeOrder) => void;
+  updateTradeFundingHistory: (uuid: string, fundingHistory: FundingHistoryEntry[]) => void;
   setNewTrades: (trades: TradeOrder[]) => void;
   resetState: () => void;
 }
@@ -40,6 +41,13 @@ export const createTradeHistorySlice: StateImmerCreator<
         }
         return trade;
       });
+    }),
+  updateTradeFundingHistory: (uuid, fundingHistory) =>
+    set((state) => {
+      const trade = state.trade_history.trades.find((t) => t.uuid === uuid);
+      if (trade) {
+        trade.fundingHistory = fundingHistory;
+      }
     }),
 
   resetState: () => {

--- a/lib/state/local/trade.ts
+++ b/lib/state/local/trade.ts
@@ -1,4 +1,4 @@
-import { TradeOrder } from "@/lib/types";
+import { FundingHistoryEntry, TradeOrder } from "@/lib/types";
 import { AccountSlices, StateImmerCreator } from "../utils";
 
 export interface TradeSlice {
@@ -6,6 +6,7 @@ export interface TradeSlice {
   addTrade: (tradeOrder: TradeOrder) => void;
   removeTrade: (tradeOrder: TradeOrder) => void;
   updateTrade: (tradeOrder: TradeOrder) => void;
+  updateTradeFundingHistory: (uuid: string, fundingHistory: FundingHistoryEntry[]) => void;
   setNewTrades: (trades: TradeOrder[]) => void;
   resetState: () => void;
 }
@@ -50,6 +51,13 @@ export const createTradeSlice: StateImmerCreator<AccountSlices, TradeSlice> = (
           }
           return trade;
         });
+      }
+    }),
+  updateTradeFundingHistory: (uuid, fundingHistory) =>
+    set((state) => {
+      const trade = state.trade.trades.find((t) => t.uuid === uuid);
+      if (trade) {
+        trade.fundingHistory = fundingHistory;
       }
     }),
   resetState: () => {

--- a/lib/state/store.ts
+++ b/lib/state/store.ts
@@ -56,7 +56,7 @@ export const createTwilightStore = () => {
         name: "twilight-",
         storage: createJSONStorage<AccountSlices>(() => localStorage),
         skipHydration: true,
-        version: 0.4,
+        version: 0.5,
         migrate: (persistedState, version) => {
           if (version === 0) {
             const newState = persistedState as AccountSlices;
@@ -83,6 +83,22 @@ export const createTwilightStore = () => {
             const newState = persistedState as AccountSlices;
             newState.optInLeaderboard = false;
             newState.hasShownOptInDialog = false;
+            return newState;
+          }
+          if (version === 0.4) {
+            const newState = persistedState as AccountSlices;
+            if (newState.trade?.trades) {
+              newState.trade.trades = newState.trade.trades.map((t) => ({
+                ...t,
+                fundingHistory: t.fundingHistory ?? undefined,
+              }));
+            }
+            if (newState.trade_history?.trades) {
+              newState.trade_history.trades = newState.trade_history.trades.map((t) => ({
+                ...t,
+                fundingHistory: t.fundingHistory ?? undefined,
+              }));
+            }
             return newState;
           }
           return persistedState as AccountSlices;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -66,6 +66,14 @@ export type UtxoData = {
 
 export type ZkAccount = z.infer<typeof ZkAccountSchema>;
 export type TradeOrder = z.infer<typeof TradeOrderSchema>;
+export type FundingHistoryEntry = {
+  time: string;
+  position_side: string;
+  payment: string;
+  funding_rate: string;
+  order_id: string;
+};
+
 export type LendOrder = z.infer<typeof LendOrderSchema>;
 export type PoolInfo = z.infer<typeof PoolInfoSchema>;
 export type TransactionHistory = z.infer<typeof TransactionHistorySchema>;


### PR DESCRIPTION
Adds per-order funding history with an Option A sync strategy (independent of the ticker):

- **API:** `queryOrderFundingHistory` calls relayer `order_funding_history`
- **Sync:** `useFundingCycleTrigger` + `useFundingHistoryRefresh` run in PriceFeedProvider; refresh on hourly boundary
- **UI:** FundingHistoryDialog with Details button in Positions, Trader History (SETTLED/LIQUIDATE), Order History, My Trades

### Unit Display Changes

- Funding and Fee columns now use **mBTC** instead of BTC
- New `formatSatsMBtc()` helper for 5-decimal precision so small amounts (e.g. funding) display correctly instead of 0