### PR TITLE
Adds **Stop Loss / Take Profit (SLTP)** support for conditional closes.

### DIFF
--- a/app/_components/trade/details/details.client.tsx
+++ b/app/_components/trade/details/details.client.tsx
@@ -57,7 +57,10 @@ const DetailsPanel = () => {
       (trade) =>
         trade.orderStatus !== "SETTLED" &&
         trade.orderStatus !== "CANCELLED" &&
-        (trade.orderStatus === "PENDING" || trade.settleLimit)
+        (trade.orderStatus === "PENDING" ||
+          trade.settleLimit ||
+          trade.takeProfit ||
+          trade.stopLoss)
     );
   }, [tradeOrders]);
 
@@ -187,7 +190,10 @@ const DetailsPanel = () => {
   );
 
   const cancelOrder = useCallback(
-    async (order: TradeOrder) => {
+    async (
+      order: TradeOrder,
+      options?: { sl_bool?: boolean; tp_bool?: boolean }
+    ) => {
       if (cancellingOrders.has(order.uuid)) return;
 
       setCancellingOrders((prev) => new Set(prev).add(order.uuid));
@@ -199,7 +205,7 @@ const DetailsPanel = () => {
             "Please do not close this page while your order is being cancelled...",
         });
 
-        const cancelOrderResult = await cancelZkOrder(order, privateKey);
+        const cancelOrderResult = await cancelZkOrder(order, privateKey, options);
 
         if (!cancelOrderResult.success) {
           toast({

--- a/app/_components/trade/details/tables/open-orders/columns.tsx
+++ b/app/_components/trade/details/tables/open-orders/columns.tsx
@@ -9,7 +9,10 @@ import Big from "big.js";
 import dayjs from "dayjs";
 
 interface OpenOrdersTableMeta {
-  cancelOrder: (order: TradeOrder) => Promise<void>;
+  cancelOrder: (
+    order: TradeOrder,
+    options?: { sl_bool?: boolean; tp_bool?: boolean }
+  ) => Promise<void>;
   openEditDialog: (order: TradeOrder) => void;
   isCancellingOrder: (uuid: string) => boolean;
 }
@@ -18,7 +21,15 @@ export const openOrdersColumns: ColumnDef<TradeOrder, any>[] = [
   {
     accessorKey: "date",
     header: "Time",
-    accessorFn: (row) => dayjs(row.date).format("DD/MM/YYYY HH:mm:ss"),
+    accessorFn: (row) => {
+      const ts =
+        row.settleLimit?.timestamp ??
+        row.takeProfit?.timestamp ??
+        row.stopLoss?.timestamp;
+      return ts
+        ? dayjs(ts).format("DD/MM/YYYY HH:mm:ss")
+        : dayjs(row.date).format("DD/MM/YYYY HH:mm:ss");
+    },
   },
   {
     accessorKey: "uuid",
@@ -73,6 +84,13 @@ export const openOrdersColumns: ColumnDef<TradeOrder, any>[] = [
     header: "Type",
     cell: ({ row }) => {
       const trade = row.original;
+      if (trade.takeProfit || trade.stopLoss) {
+        return (
+          <span className="rounded bg-purple-500/10 px-2 py-1 text-xs font-medium text-purple-500">
+            SLTP
+          </span>
+        );
+      }
       if (trade.settleLimit) {
         return (
           <span className="rounded bg-yellow-500/10 px-2 py-1 text-xs font-medium text-yellow-500">
@@ -104,6 +122,14 @@ export const openOrdersColumns: ColumnDef<TradeOrder, any>[] = [
     accessorKey: "orderType",
     header: "Order Type",
     cell: (row) => {
+      const trade = row.row.original;
+      if (trade.takeProfit || trade.stopLoss) {
+        return (
+          <span className="text-xs font-medium">
+            {capitaliseFirstLetter(trade.orderType)}
+          </span>
+        );
+      }
       const orderType = row.getValue() as string;
       return (
         <span className="text-xs font-medium">
@@ -114,9 +140,18 @@ export const openOrdersColumns: ColumnDef<TradeOrder, any>[] = [
   },
   {
     accessorKey: "entryPrice",
-    header: "Limit Price (USD)",
-    accessorFn: (row) =>
-      `$${row.settleLimit ? Number(row.settleLimit.price).toFixed(2) : row.entryPrice.toFixed(2)}`,
+    header: "Price (USD)",
+    accessorFn: (row) => {
+      if (row.takeProfit || row.stopLoss) {
+        const parts: string[] = [];
+        if (row.stopLoss)
+          parts.push(`SL: $${Number(row.stopLoss.sl_price).toFixed(2)}`);
+        if (row.takeProfit)
+          parts.push(`TP: $${Number(row.takeProfit.tp_price).toFixed(2)}`);
+        return parts.join(" / ");
+      }
+      return `$${row.settleLimit ? Number(row.settleLimit.price).toFixed(2) : row.entryPrice.toFixed(2)}`;
+    },
   },
   {
     accessorKey: "leverage",
@@ -139,21 +174,61 @@ export const openOrdersColumns: ColumnDef<TradeOrder, any>[] = [
       const trade = row.row.original;
       const meta = row.table.options.meta as OpenOrdersTableMeta;
       const isCancelling = meta.isCancellingOrder(trade.uuid);
+      const isSltp = !!(trade.takeProfit || trade.stopLoss);
+
+      if (isSltp) {
+        const hasSl = !!trade.stopLoss;
+        const hasTp = !!trade.takeProfit;
+        return (
+          <div className="flex flex-row flex-wrap justify-start gap-1">
+            {hasSl && (
+              <Button
+                onClick={async (e) => {
+                  e.preventDefault();
+                  await meta.cancelOrder(trade, { sl_bool: true });
+                }}
+                variant="ui"
+                size="small"
+                disabled={isCancelling}
+              >
+                {isCancelling ? "Cancelling..." : "Cancel SL"}
+              </Button>
+            )}
+            {hasTp && (
+              <Button
+                onClick={async (e) => {
+                  e.preventDefault();
+                  await meta.cancelOrder(trade, { tp_bool: true });
+                }}
+                variant="ui"
+                size="small"
+                disabled={isCancelling}
+              >
+                {isCancelling ? "Cancelling..." : "Cancel TP"}
+              </Button>
+            )}
+            {(hasSl || hasTp) && (
+              <Button
+                onClick={async (e) => {
+                  e.preventDefault();
+                  await meta.cancelOrder(trade, {
+                    sl_bool: hasSl,
+                    tp_bool: hasTp,
+                  });
+                }}
+                variant="ui"
+                size="small"
+                disabled={isCancelling}
+              >
+                {isCancelling ? "Cancelling..." : "Cancel Both"}
+              </Button>
+            )}
+          </div>
+        );
+      }
 
       return (
         <div className="flex flex-row justify-start gap-1">
-          {/*{!trade.settleLimit && (
-            <Button
-              onClick={(e) => {
-                e.preventDefault();
-                meta.openEditDialog(trade);
-              }}
-              variant="ui"
-              size="small"
-            >
-              Edit
-            </Button>
-          )}*/}
           <Button
             onClick={async (e) => {
               e.preventDefault();

--- a/app/_components/trade/details/tables/open-orders/open-orders-table.client.tsx
+++ b/app/_components/trade/details/tables/open-orders/open-orders-table.client.tsx
@@ -7,7 +7,10 @@ import { OpenOrdersDataTable } from './data-table';
 
 interface OpenOrdersTableProps {
   data: TradeOrder[];
-  cancelOrder: (order: TradeOrder) => Promise<void>;
+  cancelOrder: (
+    order: TradeOrder,
+    options?: { sl_bool?: boolean; tp_bool?: boolean }
+  ) => Promise<void>;
   openEditDialog: (order: TradeOrder) => void;
   isCancellingOrder: (uuid: string) => boolean;
 }

--- a/app/_components/trade/details/tables/order-history/columns.tsx
+++ b/app/_components/trade/details/tables/order-history/columns.tsx
@@ -1,5 +1,6 @@
 import Button from "@/components/button";
 import { Text } from "@/components/typography";
+import { Info } from "lucide-react";
 import cn from "@/lib/cn";
 import { capitaliseFirstLetter, formatSatsMBtc, truncateHash } from "@/lib/helpers";
 import { toast } from "@/lib/hooks/useToast";
@@ -253,7 +254,7 @@ export const orderHistoryColumns: ColumnDef<MyTradeOrder, any>[] = [
             );
 
       return (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
           <span
             className={cn(
               "font-medium",
@@ -263,17 +264,17 @@ export const orderHistoryColumns: ColumnDef<MyTradeOrder, any>[] = [
             {formatSatsMBtc(funding)}
           </span>
           {(trade.orderStatus === "SETTLED" || trade.orderStatus === "LIQUIDATE") && (
-            <Button
-              variant="ui"
-              size="small"
+            <button
+              type="button"
               onClick={(e) => {
                 e.preventDefault();
                 meta.openFundingDialog(trade);
               }}
-              className="px-2 py-0.5 text-xs"
+              className="text-primary-accent/40 hover:text-primary-accent p-0.5 rounded hover:bg-theme/20 transition-colors"
+              aria-label="View funding history"
             >
-              Details
-            </Button>
+              <Info className="h-3.5 w-3.5" />
+            </button>
           )}
         </div>
       );

--- a/app/_components/trade/details/tables/positions/columns.tsx
+++ b/app/_components/trade/details/tables/positions/columns.tsx
@@ -1,5 +1,12 @@
-import Button from '@/components/button';
-import cn from '@/lib/cn';
+import Button from "@/components/button";
+import {
+  DropdownMenu,
+  DropdownTrigger,
+  DropdownContent,
+  DropdownItem,
+} from "@/components/dropdown";
+import { ChevronDown, Info } from "lucide-react";
+import cn from "@/lib/cn";
 import { capitaliseFirstLetter, formatSatsMBtc } from '@/lib/helpers';
 import BTC from '@/lib/twilight/denoms';
 import { TradeOrder } from '@/lib/types';
@@ -16,6 +23,7 @@ interface PositionsTableMeta {
   settleMarketOrder: (trade: TradeOrder, currentPrice: number) => Promise<void>;
   isSettlingOrder: (uuid: string) => boolean;
   openLimitDialog: (account: string) => void;
+  openConditionalDialog: (account: string, mode: "limit" | "sltp") => void;
   openFundingDialog: (trade: TradeOrder) => void;
 }
 
@@ -135,7 +143,7 @@ export const positionsColumns: ColumnDef<MyTradeOrder, any>[] = [
         : Math.round(trade.initialMargin - trade.availableMargin - trade.feeFilled + pnl);
 
       return (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
           <span className={cn("font-medium",
             funding > 0 ? "text-green-medium" :
               funding < 0 ? "text-red" :
@@ -143,17 +151,17 @@ export const positionsColumns: ColumnDef<MyTradeOrder, any>[] = [
           )}>
             {formatSatsMBtc(funding)}
           </span>
-          <Button
-            variant="ui"
-            size="small"
+          <button
+            type="button"
             onClick={(e) => {
               e.preventDefault();
               meta.openFundingDialog(trade);
             }}
-            className="px-2 py-0.5 text-xs"
+            className="text-primary-accent/40 hover:text-primary-accent p-0.5 rounded hover:bg-theme/20 transition-colors"
+            aria-label="View funding history"
           >
-            Details
-          </Button>
+            <Info className="h-3.5 w-3.5" />
+          </button>
         </div>
       );
     },
@@ -205,16 +213,34 @@ export const positionsColumns: ColumnDef<MyTradeOrder, any>[] = [
           >
             {isSettling ? "Closing..." : "Close Market"}
           </Button>
-          <Button
-            onClick={() => {
-              meta.openLimitDialog(trade.accountAddress)
-            }}
-            variant="ui"
-            size="small"
-            disabled={isSettling}
-          >
-            Close Limit
-          </Button>
+          <DropdownMenu>
+            <DropdownTrigger asChild>
+              <Button
+                variant="ui"
+                size="small"
+                disabled={isSettling}
+                className="gap-1"
+              >
+                Close <ChevronDown className="h-3 w-3" />
+              </Button>
+            </DropdownTrigger>
+            <DropdownContent align="start">
+              <DropdownItem
+                onSelect={() =>
+                  meta.openConditionalDialog(trade.accountAddress, "limit")
+                }
+              >
+                Limit
+              </DropdownItem>
+              <DropdownItem
+                onSelect={() =>
+                  meta.openConditionalDialog(trade.accountAddress, "sltp")
+                }
+              >
+                SL/TP
+              </DropdownItem>
+            </DropdownContent>
+          </DropdownMenu>
         </div>
       );
     },

--- a/app/_components/trade/details/tables/positions/data-table.tsx
+++ b/app/_components/trade/details/tables/positions/data-table.tsx
@@ -19,6 +19,7 @@ interface DataTableProps<TData, TValue> {
   getCurrentPrice: () => number;
   getBtcPriceUsd: () => number;
   openLimitDialog: (account: string) => void;
+  openConditionalDialog: (account: string, mode: "limit" | "sltp") => void;
   openFundingDialog: (trade: TradeOrder) => void;
   settleMarketOrder: (trade: TradeOrder, currentPrice: number) => Promise<void>;
   isSettlingOrder: (uuid: string) => boolean;
@@ -30,6 +31,7 @@ export function PositionsDataTable<TData, TValue>({
   getCurrentPrice,
   getBtcPriceUsd,
   openLimitDialog,
+  openConditionalDialog,
   openFundingDialog,
   settleMarketOrder,
   isSettlingOrder
@@ -45,6 +47,7 @@ export function PositionsDataTable<TData, TValue>({
     getCurrentPrice,
     getBtcPriceUsd,
     openLimitDialog,
+    openConditionalDialog,
     openFundingDialog,
     settleMarketOrder,
     isSettlingOrder

--- a/app/_components/trade/details/tables/positions/positions-table.client.tsx
+++ b/app/_components/trade/details/tables/positions/positions-table.client.tsx
@@ -16,7 +16,7 @@ interface PositionsTableProps {
 }
 
 const PositionsTable = React.memo(function PositionsTable({ data, settleMarketOrder, isSettlingOrder }: PositionsTableProps) {
-  const { openLimitDialog } = useLimitDialog();
+  const { openLimitDialog, openConditionalDialog } = useLimitDialog();
   const storedBtcPrice = useSessionStore((state) => state.price.btcPrice);
 
   const [fundingDialogTrade, setFundingDialogTrade] = useState<TradeOrder | null>(null);
@@ -42,6 +42,7 @@ const PositionsTable = React.memo(function PositionsTable({ data, settleMarketOr
         settleMarketOrder={settleMarketOrder}
         isSettlingOrder={isSettlingOrder}
         openLimitDialog={openLimitDialog}
+        openConditionalDialog={openConditionalDialog}
         openFundingDialog={openFundingDialog}
       />
       <FundingHistoryDialog

--- a/app/_components/trade/details/tables/trader-history/columns.tsx
+++ b/app/_components/trade/details/tables/trader-history/columns.tsx
@@ -1,4 +1,5 @@
 import Button from '@/components/button';
+import { Info } from 'lucide-react';
 import cn from '@/lib/cn';
 import { capitaliseFirstLetter, formatSatsMBtc, truncateHash } from '@/lib/helpers';
 import { toast } from '@/lib/hooks/useToast';
@@ -157,7 +158,7 @@ export const traderHistoryColumns: ColumnDef<MyTradeOrder, any>[] = [
         : Math.round(trade.initialMargin - trade.availableMargin - trade.feeFilled - trade.feeSettled + pnl);
 
       return (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
           <span className={cn("font-medium",
             funding > 0 ? "text-green-medium" :
               funding < 0 ? "text-red" :
@@ -166,17 +167,17 @@ export const traderHistoryColumns: ColumnDef<MyTradeOrder, any>[] = [
             {formatSatsMBtc(funding)}
           </span>
           {(trade.orderStatus === "SETTLED" || trade.orderStatus === "LIQUIDATE") && (
-            <Button
-              variant="ui"
-              size="small"
+            <button
+              type="button"
               onClick={(e) => {
                 e.preventDefault();
                 meta.openFundingDialog(trade);
               }}
-              className="px-2 py-0.5 text-xs"
+              className="text-primary-accent/40 hover:text-primary-accent p-0.5 rounded hover:bg-theme/20 transition-colors"
+              aria-label="View funding history"
             >
-              Details
-            </Button>
+              <Info className="h-3.5 w-3.5" />
+            </button>
           )}
         </div>
       );

--- a/components/conditional-close-dialog.tsx
+++ b/components/conditional-close-dialog.tsx
@@ -1,0 +1,577 @@
+"use client";
+
+import { useTwilightStore } from "@/lib/providers/store";
+import React, { useEffect, useState } from "react";
+import { Dialog, DialogContent, DialogTitle } from "./dialog";
+import { NumberInput } from "./input";
+import Button from "./button";
+import { useToast } from "@/lib/hooks/useToast";
+import { settleOrder, settleOrderSltp } from "@/lib/zk/trade";
+import { useSessionStore } from "@/lib/providers/session";
+import { usePriceFeed } from "@/lib/providers/feed";
+import Link from "next/link";
+import Big from "big.js";
+import dayjs from "dayjs";
+import { useQueryClient } from "@tanstack/react-query";
+import cn from "@/lib/cn";
+import BTC from "@/lib/twilight/denoms";
+import { calculateUpnl } from "@/app/_components/trade/orderbook/my-trades/columns";
+import { formatPnlWithUsd } from "@/lib/utils/formatPnl";
+import { formatCurrency } from "@/lib/twilight/ticker";
+import { Tabs, TabsList, TabsTrigger } from "./tabs";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+type Props = {
+  account?: string;
+  initialTab?: "limit" | "sltp";
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+function ConditionalCloseDialog({
+  account,
+  initialTab = "limit",
+  open,
+  onOpenChange,
+}: Props) {
+  const { toast } = useToast();
+  const [activeTab, setActiveTab] = useState<"limit" | "sltp">(initialTab);
+
+  const trades = useTwilightStore((state) => state.trade.trades);
+  const updateTrade = useTwilightStore((state) => state.trade.updateTrade);
+  const addTradeHistory = useTwilightStore(
+    (state) => state.trade_history.addTrade
+  );
+  const privateKey = useSessionStore((state) => state.privateKey);
+  const storedBtcPrice = useSessionStore((state) => state.price.btcPrice);
+
+  const { getCurrentPrice } = usePriceFeed();
+  const liveBtcPrice = getCurrentPrice();
+  const currentPrice = liveBtcPrice || storedBtcPrice;
+
+  const [limitPrice, setLimitPrice] = useState(currentPrice || 0);
+  const [slPrice, setSlPrice] = useState<number>(0);
+  const [tpPrice, setTpPrice] = useState<number>(0);
+
+  const selectedTrade = trades.find((trade) => trade.accountAddress === account);
+  const queryClient = useQueryClient();
+
+  const entryPrice = selectedTrade?.entryPrice || 0;
+  const markPrice = currentPrice || entryPrice;
+  const positionSize = selectedTrade?.positionSize || 0;
+  const positionType = selectedTrade?.positionType || "";
+
+  const positionSizeBtc = BTC.format(
+    new BTC("sats", Big(positionSize)).convert("BTC"),
+    "BTC"
+  );
+
+  const hasSettleLimit = !!selectedTrade?.settleLimit;
+  const hasSltp = !!(
+    selectedTrade?.takeProfit ||
+    selectedTrade?.stopLoss
+  );
+
+  useEffect(() => {
+    if (open) {
+      setActiveTab(initialTab);
+      if (currentPrice) {
+        setLimitPrice(currentPrice);
+        setSlPrice(currentPrice);
+        setTpPrice(currentPrice);
+      }
+    }
+  }, [open, initialTab, currentPrice]);
+
+  const estimatedPnlLimit = calculateUpnl(
+    entryPrice,
+    limitPrice,
+    positionType,
+    positionSize
+  );
+  const estimatedPnlLimitBtc = BTC.format(
+    new BTC("sats", Big(estimatedPnlLimit)).convert("BTC"),
+    "BTC"
+  );
+  const estimatedPnlLimitUsd = formatPnlWithUsd(estimatedPnlLimit, currentPrice);
+  const isPnlLimitPositive = estimatedPnlLimit > 0;
+  const isPnlLimitNegative = estimatedPnlLimit < 0;
+
+  const estimatedPnlSl = calculateUpnl(
+    entryPrice,
+    slPrice,
+    positionType,
+    positionSize
+  );
+  const estimatedPnlTp = calculateUpnl(
+    entryPrice,
+    tpPrice,
+    positionType,
+    positionSize
+  );
+
+  function validateSltp(): string | null {
+    if (!selectedTrade) return "Please select a valid trade";
+    const hasSl = slPrice > 0;
+    const hasTp = tpPrice > 0;
+    if (!hasSl && !hasTp) {
+      return "At least one of Stop Loss or Take Profit is required";
+    }
+    if (hasSl && hasTp && Math.abs(slPrice - tpPrice) < 0.01) {
+      return "Stop Loss and Take Profit cannot be the same";
+    }
+    const isLong = positionType.toUpperCase() === "LONG";
+    if (hasSl) {
+      if (isLong && slPrice >= entryPrice) {
+        return "For LONG: Stop Loss must be below entry price";
+      }
+      if (!isLong && slPrice <= entryPrice) {
+        return "For SHORT: Stop Loss must be above entry price";
+      }
+    }
+    if (hasTp) {
+      if (isLong && tpPrice <= entryPrice) {
+        return "For LONG: Take Profit must be above entry price";
+      }
+      if (!isLong && tpPrice >= entryPrice) {
+        return "For SHORT: Take Profit must be below entry price";
+      }
+    }
+    return null;
+  }
+
+  async function handleSettleLimit() {
+    if (limitPrice < 0) {
+      toast({
+        title: "Invalid limit price",
+        description: "Please enter a valid limit price",
+        variant: "error",
+      });
+      return;
+    }
+    if (!selectedTrade) {
+      toast({
+        title: "Invalid trade",
+        description: "Please select a valid trade",
+        variant: "error",
+      });
+      return;
+    }
+    if (hasSltp) {
+      toast({
+        title: "Cancel SLTP first",
+        description: "You have SL/TP orders. Cancel them first to place a limit close.",
+        variant: "error",
+      });
+      return;
+    }
+
+    onOpenChange(false);
+    toast({
+      title: "Closing position",
+      description:
+        "Please do not close this page while your position is being closed...",
+    });
+
+    const result = await settleOrder(
+      selectedTrade,
+      "limit",
+      privateKey,
+      limitPrice
+    );
+
+    if (!result.success) {
+      toast({
+        title: "Error settling order",
+        description: result.message,
+        variant: "error",
+      });
+      return;
+    }
+
+    const settledData = result.data;
+
+    const updatedTradeData = {
+      ...selectedTrade,
+      orderStatus: settledData.order_status,
+      availableMargin: Big(settledData.available_margin).toNumber(),
+      maintenanceMargin: Big(settledData.maintenance_margin).toNumber(),
+      unrealizedPnl: Big(settledData.unrealized_pnl).toNumber(),
+      settlementPrice: Big(settledData.settlement_price).toNumber(),
+      positionSize: Big(settledData.positionsize).toNumber(),
+      orderType: settledData.order_type,
+      date: dayjs(settledData.timestamp).toDate(),
+      exit_nonce: settledData.exit_nonce,
+      executionPrice: Big(settledData.execution_price).toNumber(),
+      isOpen: false,
+      feeSettled: Big(settledData.fee_settled).toNumber(),
+      feeFilled: Big(settledData.fee_filled).toNumber(),
+      realizedPnl: Big(settledData.unrealized_pnl).toNumber(),
+      tx_hash: settledData.tx_hash || selectedTrade.tx_hash,
+      liquidationPrice: Big(settledData.liquidation_price).toNumber(),
+      bankruptcyPrice: Big(settledData.bankruptcy_price).toNumber(),
+      bankruptcyValue: Big(settledData.bankruptcy_value).toNumber(),
+      initialMargin: Big(settledData.initial_margin).toNumber(),
+      settleLimit: settledData.settle_limit
+        ? {
+            ...settledData.settle_limit,
+            timestamp: settledData.settle_limit.timestamp,
+          }
+        : null,
+      fundingApplied: settledData.funding_applied,
+    };
+
+    updateTrade(updatedTradeData);
+    addTradeHistory({
+      ...updatedTradeData,
+      positionType:
+        settledData.settle_limit?.position_type ||
+        updatedTradeData.positionType,
+      entryPrice: settledData.settle_limit
+        ? Number(settledData.settle_limit.price)
+        : updatedTradeData.entryPrice,
+      orderStatus: "PENDING",
+      orderType: "LIMIT",
+      date: new Date(),
+    });
+
+    await queryClient.invalidateQueries({ queryKey: ["sync-trades"] });
+
+    toast({
+      title: "Limit order sent",
+      description: (
+        <div className="opacity-90">
+          Close position limit order sent.{" "}
+          {settledData.tx_hash && (
+            <Link
+              href={`${process.env.NEXT_PUBLIC_EXPLORER_URL as string}/txs/${settledData.tx_hash}`}
+              target={"_blank"}
+              className="text-sm underline hover:opacity-100"
+            >
+              Explorer link
+            </Link>
+          )}
+        </div>
+      ),
+    });
+  }
+
+  async function handleSettleSltp() {
+    const err = validateSltp();
+    if (err) {
+      toast({
+        title: "Invalid SLTP",
+        description: err,
+        variant: "error",
+      });
+      return;
+    }
+    if (!selectedTrade) return;
+    if (hasSettleLimit) {
+      toast({
+        title: "Cancel limit first",
+        description:
+          "You have a limit close order. Cancel it first to place SLTP.",
+        variant: "error",
+      });
+      return;
+    }
+
+    onOpenChange(false);
+    toast({
+      title: "Placing SLTP order",
+      description:
+        "Please do not close this page while your order is being processed...",
+    });
+
+    const sl = slPrice > 0 ? slPrice : undefined;
+    const tp = tpPrice > 0 ? tpPrice : undefined;
+
+    const result = await settleOrderSltp(
+      selectedTrade,
+      privateKey,
+      currentPrice || entryPrice,
+      sl,
+      tp
+    );
+
+    if (!result.success) {
+      toast({
+        title: "Error placing SLTP",
+        description: result.message,
+        variant: "error",
+      });
+      return;
+    }
+
+    const settledData = result.data;
+
+    const updatedTradeData = {
+      ...selectedTrade,
+      orderStatus: settledData.order_status,
+      availableMargin: Big(settledData.available_margin).toNumber(),
+      maintenanceMargin: Big(settledData.maintenance_margin).toNumber(),
+      unrealizedPnl: Big(settledData.unrealized_pnl).toNumber(),
+      settlementPrice: Big(settledData.settlement_price).toNumber(),
+      positionSize: Big(settledData.positionsize).toNumber(),
+      orderType: settledData.order_type,
+      date: dayjs(settledData.timestamp).toDate(),
+      exit_nonce: settledData.exit_nonce,
+      executionPrice: Big(settledData.execution_price).toNumber(),
+      isOpen: false,
+      feeSettled: Big(settledData.fee_settled).toNumber(),
+      feeFilled: Big(settledData.fee_filled).toNumber(),
+      realizedPnl: Big(settledData.unrealized_pnl).toNumber(),
+      tx_hash: settledData.tx_hash || selectedTrade.tx_hash,
+      liquidationPrice: Big(settledData.liquidation_price).toNumber(),
+      bankruptcyPrice: Big(settledData.bankruptcy_price).toNumber(),
+      bankruptcyValue: Big(settledData.bankruptcy_value).toNumber(),
+      initialMargin: Big(settledData.initial_margin).toNumber(),
+      takeProfit: settledData.take_profit ?? undefined,
+      stopLoss: settledData.stop_loss ?? undefined,
+      fundingApplied: settledData.funding_applied,
+    };
+
+    updateTrade(updatedTradeData);
+    addTradeHistory({
+      ...updatedTradeData,
+      orderStatus: "PENDING",
+      orderType: "SLTP",
+      takeProfit: settledData.take_profit ?? undefined,
+      stopLoss: settledData.stop_loss ?? undefined,
+      date: new Date(),
+    });
+
+    await queryClient.invalidateQueries({ queryKey: ["sync-trades"] });
+
+    toast({
+      title: "SLTP order sent",
+      description: "Stop Loss / Take Profit order has been placed.",
+    });
+  }
+
+  function applyPreset(preset: "sl-2" | "tp-5" | "sl-2-tp-5") {
+    const isLong = positionType.toUpperCase() === "LONG";
+    if (preset === "sl-2") {
+      setSlPrice(isLong ? entryPrice * 0.98 : entryPrice * 1.02);
+    } else if (preset === "tp-5") {
+      setTpPrice(isLong ? entryPrice * 1.05 : entryPrice * 0.95);
+    } else {
+      setSlPrice(isLong ? entryPrice * 0.98 : entryPrice * 1.02);
+      setTpPrice(isLong ? entryPrice * 1.05 : entryPrice * 0.95);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle>Close Position</DialogTitle>
+        <Tabs
+          value={activeTab}
+          onValueChange={(v) => setActiveTab(v as "limit" | "sltp")}
+        >
+          <TabsList variant="underline" className="w-full">
+            <TabsTrigger value="limit" variant="underline">
+              Limit
+            </TabsTrigger>
+            <TabsTrigger value="sltp" variant="underline">
+              SL/TP
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsPrimitive.Content value="limit" className="mt-4">
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-primary-accent">
+                  Entry Price (USD)
+                </span>
+                <span className="text-sm font-medium">
+                  {formatCurrency(entryPrice)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-primary-accent">
+                  Mark Price (USD)
+                </span>
+                <span className="text-sm font-medium">
+                  {formatCurrency(markPrice)}
+                </span>
+              </div>
+              <div className="border-t" />
+              <div className="space-y-1">
+                <label
+                  className="text-xs text-primary-accent"
+                  htmlFor="input-limit-amount-usd"
+                >
+                  Limit Price (USD)
+                </label>
+                <NumberInput
+                  id="input-limit-amount-usd"
+                  inputValue={limitPrice}
+                  setInputValue={setLimitPrice}
+                  currentPrice={currentPrice}
+                  placeholder="0.00"
+                />
+              </div>
+              <div className="border-t" />
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-primary-accent">
+                  Position Amount
+                </span>
+                <span className="text-sm font-medium">{positionSizeBtc} BTC</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-primary-accent">
+                  Estimated PnL
+                </span>
+                <span
+                  className={cn(
+                    "text-sm font-medium",
+                    isPnlLimitPositive && "text-green-medium",
+                    isPnlLimitNegative && "text-red",
+                    !isPnlLimitPositive && !isPnlLimitNegative && "text-gray-500"
+                  )}
+                >
+                  {isPnlLimitPositive ? "+" : ""}
+                  {estimatedPnlLimitBtc} BTC ({estimatedPnlLimitUsd})
+                </span>
+              </div>
+              <div className="border-t" />
+              <Button onClick={handleSettleLimit}>Confirm</Button>
+            </div>
+          </TabsPrimitive.Content>
+
+          <TabsPrimitive.Content value="sltp" className="mt-4">
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-primary-accent">
+                  Entry Price (USD)
+                </span>
+                <span className="text-sm font-medium">
+                  {formatCurrency(entryPrice)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-primary-accent">
+                  Mark Price (USD)
+                </span>
+                <span className="text-sm font-medium">
+                  {formatCurrency(markPrice)}
+                </span>
+              </div>
+              <div className="border-t" />
+
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs text-primary-accent shrink-0">
+                  Quick presets
+                </span>
+                <div className="flex gap-1">
+                  <Button
+                    variant="ui"
+                    size="small"
+                    onClick={() => applyPreset("sl-2")}
+                    className="text-xs"
+                  >
+                    SL -2%
+                  </Button>
+                  <Button
+                    variant="ui"
+                    size="small"
+                    onClick={() => applyPreset("tp-5")}
+                    className="text-xs"
+                  >
+                    TP +5%
+                  </Button>
+                  <Button
+                    variant="ui"
+                    size="small"
+                    onClick={() => applyPreset("sl-2-tp-5")}
+                    className="text-xs"
+                  >
+                    Both
+                  </Button>
+                </div>
+              </div>
+
+              <div className="space-y-1">
+                <label
+                  className="text-xs text-primary-accent"
+                  htmlFor="input-sl-usd"
+                >
+                  Stop Loss (USD) — optional
+                </label>
+                <NumberInput
+                  id="input-sl-usd"
+                  inputValue={slPrice}
+                  setInputValue={setSlPrice}
+                  currentPrice={currentPrice}
+                  placeholder="0.00"
+                />
+                {slPrice > 0 && (
+                  <span
+                    className={cn(
+                      "text-xs",
+                      estimatedPnlSl < 0 ? "text-red" : "text-green-medium"
+                    )}
+                  >
+                    PnL at SL: {formatPnlWithUsd(estimatedPnlSl, currentPrice)}
+                  </span>
+                )}
+              </div>
+
+              <div className="space-y-1">
+                <label
+                  className="text-xs text-primary-accent"
+                  htmlFor="input-tp-usd"
+                >
+                  Take Profit (USD) — optional
+                </label>
+                <NumberInput
+                  id="input-tp-usd"
+                  inputValue={tpPrice}
+                  setInputValue={setTpPrice}
+                  currentPrice={currentPrice}
+                  placeholder="0.00"
+                />
+                {tpPrice > 0 && (
+                  <span
+                    className={cn(
+                      "text-xs",
+                      estimatedPnlTp >= 0 ? "text-green-medium" : "text-red"
+                    )}
+                  >
+                    PnL at TP: {formatPnlWithUsd(estimatedPnlTp, currentPrice)}
+                  </span>
+                )}
+              </div>
+
+              {slPrice > 0 && tpPrice > 0 && (
+                <div className="flex items-center justify-between text-xs text-primary-accent">
+                  <span>Risk/Reward</span>
+                  <span>
+                    {(
+                      Math.abs(estimatedPnlTp) / Math.abs(estimatedPnlSl || 1)
+                    ).toFixed(2)}
+                    :1
+                  </span>
+                </div>
+              )}
+
+              <div className="border-t" />
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-primary-accent">
+                  Position Amount
+                </span>
+                <span className="text-sm font-medium">{positionSizeBtc} BTC</span>
+              </div>
+              <div className="border-t" />
+              <Button onClick={handleSettleSltp}>Confirm</Button>
+            </div>
+          </TabsPrimitive.Content>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default ConditionalCloseDialog;

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -109,4 +109,34 @@ async function executeTradeOrder(msg: string) {
   return data;
 }
 
-export { sendTradeOrder, sendLendOrder, executeTradeOrder, executeLendOrder };
+async function executeTradeOrderSltp(msg: string) {
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    method: "ExecuteTraderOrderSlTp",
+    params: {
+      data: msg,
+    },
+    id: 1,
+  });
+
+  const { success, data, error } = await wfetch(CLIENT_URL)
+    .post({ body })
+    .json<Record<string, any>>();
+
+  if (!success) {
+    console.error(error);
+
+    return {};
+  }
+
+  console.log("success sent execute trade order SLTP", data);
+  return data;
+}
+
+export {
+  sendTradeOrder,
+  sendLendOrder,
+  executeTradeOrder,
+  executeTradeOrderSltp,
+  executeLendOrder,
+};

--- a/lib/api/relayer.ts
+++ b/lib/api/relayer.ts
@@ -1,6 +1,9 @@
 import dayjs from "dayjs";
 import wfetch from "../http";
-import { createCancelTraderOrderMsg } from "../twilight/zkos";
+import {
+  createCancelTraderOrderMsg,
+  createCancelTraderOrderSltpMsg,
+} from "../twilight/zkos";
 import { FundingHistoryEntry, QueryLendOrderData } from "../types";
 
 const RELAYER_PUBLIC_URL = process.env
@@ -68,6 +71,48 @@ async function cancelTradeOrder({
   return data;
 }
 
+async function cancelTradeOrderSlTp({
+  address,
+  uuid,
+  signature,
+  sl_bool,
+  tp_bool,
+}: {
+  address: string;
+  uuid: string;
+  signature: string;
+  sl_bool: boolean;
+  tp_bool: boolean;
+}) {
+  const msg = await createCancelTraderOrderSltpMsg({
+    address,
+    signature,
+    uuid,
+    sl_bool,
+    tp_bool,
+  });
+
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    method: "CancelTraderOrderSlTp",
+    params: {
+      data: msg,
+    },
+    id: 1,
+  });
+
+  const { success, data, error } = await wfetch(RELAYER_PUBLIC_URL)
+    .post({ body })
+    .json<Record<string, any>>();
+
+  if (!success) {
+    console.error("cancel trade order SLTP error", error);
+    return {};
+  }
+
+  return data;
+}
+
 export type QueryTradeOrderData = {
   account_id: string;
   available_margin: string;
@@ -97,6 +142,15 @@ export type QueryTradeOrderData = {
     position_type: "LONG" | "SHORT";
     price: string;
     uuid: string;
+    timestamp?: string;
+  };
+  take_profit: null | {
+    tp_price: string;
+    timestamp: string;
+  };
+  stop_loss: null | {
+    sl_price: string;
+    timestamp: string;
   };
   funding_applied: string;
 };
@@ -164,4 +218,10 @@ async function queryOrderFundingHistory(msg: string) {
   return result as FundingHistoryEntry[];
 }
 
-export { queryLendOrder, queryTradeOrder, cancelTradeOrder, queryOrderFundingHistory };
+export {
+  queryLendOrder,
+  queryTradeOrder,
+  cancelTradeOrder,
+  cancelTradeOrderSlTp,
+  queryOrderFundingHistory,
+};

--- a/lib/hooks/useReconcileOrphanedAccounts.ts
+++ b/lib/hooks/useReconcileOrphanedAccounts.ts
@@ -152,6 +152,8 @@ export const useReconcileOrphanedAccounts = () => {
             feeSettled: new Big(traderOrderInfo.fee_settled || 0).toNumber(),
             exit_nonce: traderOrderInfo.exit_nonce,
             settleLimit: traderOrderInfo.settle_limit,
+            takeProfit: traderOrderInfo.take_profit ?? undefined,
+            stopLoss: traderOrderInfo.stop_loss ?? undefined,
             fundingApplied: traderOrderInfo.funding_applied,
           };
 

--- a/lib/hooks/useSyncTrades.tsx
+++ b/lib/hooks/useSyncTrades.tsx
@@ -68,6 +68,8 @@ const tradeInfoKeysToTradeKey = {
   fee_settled: "feeSettled",
   output: "output",
   settle_limit: "settleLimit",
+  take_profit: "takeProfit",
+  stop_loss: "stopLoss",
   funding_applied: "fundingApplied",
 };
 

--- a/lib/providers/limit-dialogs.tsx
+++ b/lib/providers/limit-dialogs.tsx
@@ -1,5 +1,11 @@
-import SettleLimitDialog from '@/components/settle-limit-dialog';
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import ConditionalCloseDialog from "@/components/conditional-close-dialog";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 
 type DialogProviderProps = {
   children: React.ReactNode;
@@ -7,11 +13,13 @@ type DialogProviderProps = {
 
 type UseDialogProps = {
   openLimitDialog: (account: string) => void;
+  openConditionalDialog: (account: string, mode: "limit" | "sltp") => void;
   isOpenLimitDialog: boolean;
 };
 
 const defaultContext: UseDialogProps = {
-  openLimitDialog: () => { },
+  openLimitDialog: () => {},
+  openConditionalDialog: () => {},
   isOpenLimitDialog: false,
 };
 
@@ -26,25 +34,44 @@ export const DialogProvider: React.FC<DialogProviderProps> = (props) => {
 const Dialog: React.FC<DialogProviderProps> = ({ children }) => {
   const [isOpenLimitDialog, setIsOpenLimitDialog] = useState(false);
   const [account, setAccount] = useState<string>("");
+  const [initialTab, setInitialTab] = useState<"limit" | "sltp">("limit");
 
   const openLimitDialog = useCallback((newAccount: string) => {
     setAccount(newAccount);
+    setInitialTab("limit");
     setIsOpenLimitDialog(true);
   }, []);
 
-  const values = useMemo(() => ({
-    openLimitDialog,
-    isOpenLimitDialog,
-    account,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [isOpenLimitDialog, account, openLimitDialog])
+  const openConditionalDialog = useCallback(
+    (newAccount: string, mode: "limit" | "sltp") => {
+      setAccount(newAccount);
+      setInitialTab(mode);
+      setIsOpenLimitDialog(true);
+    },
+    []
+  );
+
+  const values = useMemo(
+    () => ({
+      openLimitDialog,
+      openConditionalDialog,
+      isOpenLimitDialog,
+      account,
+    }),
+    [isOpenLimitDialog, account, openLimitDialog, openConditionalDialog]
+  );
 
   return (
     <dialogContext.Provider value={values}>
-      <SettleLimitDialog account={account} open={isOpenLimitDialog} onOpenChange={setIsOpenLimitDialog} />
+      <ConditionalCloseDialog
+        account={account}
+        initialTab={initialTab}
+        open={isOpenLimitDialog}
+        onOpenChange={setIsOpenLimitDialog}
+      />
       {children}
     </dialogContext.Provider>
-  )
-}
+  );
+};
 
-export default DialogProvider
+export default DialogProvider;

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -45,8 +45,23 @@ export const TradeOrderSchema = z.object({
       position_type: z.enum(["LONG", "SHORT"]),
       price: z.string(),
       uuid: z.string(),
+      timestamp: z.string().optional(),
     })
     .nullable(),
+  takeProfit: z
+    .object({
+      tp_price: z.string(),
+      timestamp: z.string(),
+    })
+    .nullable()
+    .optional(),
+  stopLoss: z
+    .object({
+      sl_price: z.string(),
+      timestamp: z.string(),
+    })
+    .nullable()
+    .optional(),
   fundingApplied: z.string().nullable(),
   fundingHistory: z
     .array(

--- a/lib/state/store.ts
+++ b/lib/state/store.ts
@@ -56,7 +56,7 @@ export const createTwilightStore = () => {
         name: "twilight-",
         storage: createJSONStorage<AccountSlices>(() => localStorage),
         skipHydration: true,
-        version: 0.5,
+        version: 0.6,
         migrate: (persistedState, version) => {
           if (version === 0) {
             const newState = persistedState as AccountSlices;
@@ -97,6 +97,27 @@ export const createTwilightStore = () => {
               newState.trade_history.trades = newState.trade_history.trades.map((t) => ({
                 ...t,
                 fundingHistory: t.fundingHistory ?? undefined,
+              }));
+            }
+            return newState;
+          }
+          if (version === 0.5) {
+            const newState = persistedState as AccountSlices;
+            if (newState.trade?.trades) {
+              newState.trade.trades = newState.trade.trades.map((t) => ({
+                ...t,
+                takeProfit: t.takeProfit ?? undefined,
+                stopLoss: t.stopLoss ?? undefined,
+                settleLimit: t.settleLimit
+                  ? { ...t.settleLimit, timestamp: t.settleLimit.timestamp ?? undefined }
+                  : t.settleLimit,
+              }));
+            }
+            if (newState.trade_history?.trades) {
+              newState.trade_history.trades = newState.trade_history.trades.map((t) => ({
+                ...t,
+                takeProfit: t.takeProfit ?? undefined,
+                stopLoss: t.stopLoss ?? undefined,
               }));
             }
             return newState;

--- a/lib/twilight/zk.ts
+++ b/lib/twilight/zk.ts
@@ -260,7 +260,7 @@ async function createZkOrder({
   signature: string;
   value: number;
   positionType: PositionTypes;
-  orderType: OrderTypes;
+  orderType: Exclude<OrderTypes, "SLTP">;
   leverage: number;
   entryPrice?: number;
   timebounds: number;

--- a/lib/twilight/zkos.ts
+++ b/lib/twilight/zkos.ts
@@ -323,6 +323,67 @@ async function executeTradeLendOrderMsg({
   );
 }
 
+async function executeTradeLendOrderSltpMsg({
+  outputMemo,
+  signature,
+  address,
+  uuid,
+  orderType,
+  orderStatus,
+  executionPricePoolshare,
+  transactionType,
+  sl,
+  tp,
+}: {
+  outputMemo: string;
+  signature: string;
+  address: string;
+  uuid: string;
+  orderType: string;
+  orderStatus: string;
+  executionPricePoolshare: number;
+  transactionType: "ORDERTX" | "LENDTX";
+  sl?: number | null;
+  tp?: number | null;
+}) {
+  const zkos = await initZkos();
+  return zkos.executeTradeLendOrderZkOSSlTp(
+    outputMemo,
+    signature,
+    address,
+    uuid,
+    orderType,
+    orderStatus,
+    executionPricePoolshare,
+    transactionType,
+    sl ?? null,
+    tp ?? null
+  );
+}
+
+async function createCancelTraderOrderSltpMsg({
+  address,
+  signature,
+  uuid,
+  sl_bool,
+  tp_bool,
+}: {
+  address: string;
+  signature: string;
+  uuid: string;
+  sl_bool: boolean;
+  tp_bool: boolean;
+}) {
+  const zkos = await initZkos();
+  return zkos.cancelTraderOrderZkOSSlTp(
+    address,
+    signature,
+    JSON.stringify(uuid),
+    sl_bool,
+    tp_bool
+  );
+}
+
 async function coinAddressMonitoring({
   utxoOutputString,
   signature,
@@ -395,6 +456,7 @@ export {
   createQueryLendOrderMsg,
   createZkOSLendOrder,
   executeTradeLendOrderMsg,
+  executeTradeLendOrderSltpMsg,
   coinAddressMonitoring,
   createBurnMessageTx,
   getUpdatedAddressFromTransaction,
@@ -402,4 +464,5 @@ export {
   verifyQuisQuisTransaction,
   verifyAccount,
   createCancelTraderOrderMsg,
+  createCancelTraderOrderSltpMsg,
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -80,7 +80,7 @@ export type TransactionHistory = z.infer<typeof TransactionHistorySchema>;
 export type WithdrawOrder = z.infer<typeof WithdrawOrderSchema>;
 
 export type PositionTypes = "LONG" | "SHORT";
-export type OrderTypes = "LIMIT" | "MARKET" | "DARK" | "LEND";
+export type OrderTypes = "LIMIT" | "MARKET" | "DARK" | "LEND" | "SLTP";
 
 export enum CandleInterval {
   ONE_MINUTE = "ONE_MINUTE",

--- a/lib/zk/trade.ts
+++ b/lib/zk/trade.ts
@@ -4,10 +4,12 @@ import { retry } from "../helpers";
 import {
   createQueryTradeOrderMsg,
   executeTradeLendOrderMsg,
+  executeTradeLendOrderSltpMsg,
 } from "../twilight/zkos";
-import { executeTradeOrder } from "@/lib/api/client";
+import { executeTradeOrder, executeTradeOrderSltp } from "@/lib/api/client";
 import {
   cancelTradeOrder,
+  cancelTradeOrderSlTp,
   queryTradeOrder,
   QueryTradeOrderData,
 } from "../api/relayer";
@@ -240,18 +242,159 @@ export async function settleOrder(
   }
 }
 
+export async function settleOrderSltp(
+  trade: TradeOrder,
+  privateKey: string,
+  executionPrice: number,
+  sl?: number | null,
+  tp?: number | null
+): Promise<
+  SuccessResult<QueryTradeOrderData & { tx_hash?: string }> | FailureResult
+> {
+  try {
+    if (trade.orderStatus !== "FILLED") {
+      return {
+        success: false,
+        message: "Only filled orders can be settled",
+      };
+    }
+
+    if ((sl == null || sl === 0) && (tp == null || tp === 0)) {
+      return {
+        success: false,
+        message: "At least one of Stop Loss or Take Profit is required",
+      };
+    }
+
+    let output = trade.output;
+
+    if (!output) {
+      const transactionHashCondition = (
+        txHashResult: Awaited<ReturnType<typeof queryTransactionHashes>>
+      ) => {
+        if (txHashResult.result) {
+          let hasSettled = false;
+          txHashResult.result.forEach((result) => {
+            if (result.output && result.order_id === trade.uuid) {
+              hasSettled = true;
+            }
+          });
+          return hasSettled;
+        }
+        return false;
+      };
+
+      const transactionHashRes = await retry<
+        ReturnType<typeof queryTransactionHashes>,
+        string
+      >(
+        queryTransactionHashes,
+        30,
+        trade.accountAddress,
+        1000,
+        transactionHashCondition
+      );
+
+      if (!transactionHashRes.success) {
+        return {
+          success: false,
+          message:
+            "Failed to get output for the trade, please check the console for more details",
+        };
+      }
+
+      output = transactionHashRes.data.result.find(
+        (result) => result.order_id === trade.uuid && result.output
+      )?.output;
+
+      if (typeof output !== "string") {
+        return {
+          success: false,
+          message:
+            "Failed to get output for the trade, please check the console for more details",
+        };
+      }
+    }
+
+    const msg = await executeTradeLendOrderSltpMsg({
+      address: trade.accountAddress,
+      orderStatus: "FILLED",
+      orderType: "SLTP",
+      outputMemo: output,
+      transactionType: "ORDERTX",
+      uuid: trade.uuid,
+      signature: privateKey,
+      executionPricePoolshare: executionPrice,
+      sl: sl ?? null,
+      tp: tp ?? null,
+    });
+
+    await executeTradeOrderSltp(msg);
+
+    const queryTradeOrderMsg = await createQueryTradeOrderMsg({
+      address: trade.accountAddress,
+      orderStatus: "FILLED",
+      signature: privateKey,
+    });
+
+    const queryTradeOrderResponse = await queryTradeOrder(queryTradeOrderMsg);
+
+    if (!queryTradeOrderResponse || !queryTradeOrderResponse.result) {
+      return {
+        success: false,
+        message:
+          "Failed to query trade order details, please check the console for more details",
+      };
+    }
+
+    return {
+      success: true,
+      data: queryTradeOrderResponse.result,
+    };
+  } catch (err) {
+    console.error(`settleOrderSltp error:`, err);
+    return {
+      success: false,
+      message:
+        "Failed to place SLTP order, please check the console for more details.",
+    };
+  }
+}
+
+export type CancelZkOrderOptions = {
+  sl_bool?: boolean;
+  tp_bool?: boolean;
+};
+
 export async function cancelZkOrder(
   trade: TradeOrder,
-  privateKey: string
+  privateKey: string,
+  options?: CancelZkOrderOptions
 ): Promise<
   SuccessResult<QueryTradeOrderData & { tx_hash: string }> | FailureResult
 > {
   try {
-    const cancelResult = await cancelTradeOrder({
-      address: trade.accountAddress,
-      uuid: trade.uuid,
-      signature: privateKey,
-    });
+    const isSltp = !!(trade.takeProfit || trade.stopLoss);
+
+    let cancelResult: Record<string, unknown>;
+
+    if (isSltp) {
+      const sl_bool = options?.sl_bool ?? !!trade.stopLoss;
+      const tp_bool = options?.tp_bool ?? !!trade.takeProfit;
+      cancelResult = await cancelTradeOrderSlTp({
+        address: trade.accountAddress,
+        uuid: trade.uuid,
+        signature: privateKey,
+        sl_bool,
+        tp_bool,
+      });
+    } else {
+      cancelResult = await cancelTradeOrder({
+        address: trade.accountAddress,
+        uuid: trade.uuid,
+        signature: privateKey,
+      });
+    }
 
     console.log("cancelResult", cancelResult);
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@selfxyz/qrcode": "^1.0.15",
     "@tanstack/react-query": "^5.80.7",
     "@tanstack/react-table": "^8.10.7",
-    "@twilight-dev/zkos-wasm": "^0.1.3",
+    "@twilight-dev/zkos-wasm": "^0.1.4",
     "@types/node": "20.5.0",
     "@types/react": "18.2.20",
     "@types/react-dom": "18.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^8.10.7
         version: 8.21.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@twilight-dev/zkos-wasm':
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^0.1.4
+        version: 0.1.4
       '@types/node':
         specifier: 20.5.0
         version: 20.5.0
@@ -726,24 +726,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@13.5.9':
     resolution: {integrity: sha512-6VpS+bodQqzOeCwGxoimlRoosiWlSc0C224I7SQWJZoyJuT1ChNCo+45QQH+/GtbR/s7nhaUqmiHdzZC9TXnXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@13.5.9':
     resolution: {integrity: sha512-XxG3yj61WDd28NA8gFASIR+2viQaYZEFQagEodhI/R49gXWnYhiflTeeEmCn7Vgnxa/OfK81h1gvhUZ66lozpw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@13.5.9':
     resolution: {integrity: sha512-/dnscWqfO3+U8asd+Fc6dwL2l9AZDl7eKtPNKW8mKLh4Y4wOpjJiamhe8Dx+D+Oq0GYVjuW0WwjIxYWVozt2bA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@13.5.9':
     resolution: {integrity: sha512-T/iPnyurOK5a4HRUcxAlss8uzoEf5h9tkd+W2dSWAfzxv8WLKlUgbfk+DH43JY3Gc2xK5URLuXrxDZ2mGfk/jw==}
@@ -1434,8 +1438,8 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
-  '@twilight-dev/zkos-wasm@0.1.3':
-    resolution: {integrity: sha512-xuOTjhOCgi9sRntnyYyuBwTXFKrceNkbHXFLCWGu5W0GrNbmFLaxKwsNQwsMCxwENQ+iqVyjBUc3zMc916E3LA==}
+  '@twilight-dev/zkos-wasm@0.1.4':
+    resolution: {integrity: sha512-udCoPrffL45TmjEs1C+ptJUrm89U6vzuBLLVyECtWsVcU4BrGu/UxKkHDlyNQfTsW634h8DxUxDoLYh0HLGTvQ==}
 
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
@@ -1588,41 +1592,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1982,6 +1994,9 @@ packages:
 
   bn.js@5.2.2:
     resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
   bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
@@ -4181,8 +4196,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  styled-components@6.3.8:
-    resolution: {integrity: sha512-Kq/W41AKQloOqKM39zfaMdJ4BcYDw/N5CIq4/GTI0YjU6pKcZ1KKhk6b4du0a+6RA9pIfOP/eu94Ge7cu+PDCA==}
+  styled-components@6.3.11:
+    resolution: {integrity: sha512-opzgceGlQ5rdZdGwf9ddLW7EM2F4L7tgsgLn6fFzQ2JgE5EVQ4HZwNkcgB1p8WfOBx1GEZP3fa66ajJmtXhSrA==}
     engines: {node: '>= 16'}
     peerDependencies:
       react: '>= 16.8.0'
@@ -5637,7 +5652,7 @@ snapshots:
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/logger': 5.8.0
       '@ethersproject/properties': 5.8.0
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       elliptic: 6.6.1
       hash.js: 1.1.7
 
@@ -5742,7 +5757,7 @@ snapshots:
   '@iden3/binfileutils@0.0.11':
     dependencies:
       fastfile: 0.0.20
-      ffjavascript: 0.2.63
+      ffjavascript: 0.2.56
 
   '@iden3/binfileutils@0.0.12':
     dependencies:
@@ -6626,7 +6641,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       snarkjs: 0.7.5
-      styled-components: 6.3.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      styled-components: 6.3.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       uuid: 9.0.1
       valid-url: 1.0.9
       web-worker: 1.2.0
@@ -6766,7 +6781,7 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
-  '@twilight-dev/zkos-wasm@0.1.3': {}
+  '@twilight-dev/zkos-wasm@0.1.4': {}
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
@@ -7585,6 +7600,8 @@ snapshots:
   bn.js@4.12.2: {}
 
   bn.js@5.2.2: {}
+
+  bn.js@5.2.3: {}
 
   bowser@2.11.0: {}
 
@@ -10115,7 +10132,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-components@6.3.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  styled-components@6.3.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@emotion/is-prop-valid': 1.4.0
       '@emotion/unitless': 0.10.0


### PR DESCRIPTION
Users can set SL and/or TP on open positions and manage them from the Open Orders tab.

## What's included

### Core functionality
- **SLTP execution**: Place SLTP orders via `ExecuteTraderOrderSlTp` (same endpoint family as regular execute trades)
- **SLTP cancellation**: Cancel SL, TP, or both via `CancelTraderOrderSlTp` with `sl_bool`/`tp_bool` flags
- **ConditionalCloseDialog**: Unified dialog with Limit and SLTP tabs; SL/TP validation for LONG/SHORT; quick presets (SL -2%, TP +5%, Both); risk/reward display; mutual exclusivity with limit orders

### Data & sync
- Schema extended with `takeProfit` and `stopLoss`; `settleLimit.timestamp` added
- Store migration (v0.6) for new fields
- Sync and reconciliation mappings for `take_profit`/`stop_loss` from API

### UI changes
- **Positions**: "Close" dropdown with Limit and SL/TP options
- **Open Orders**: SLTP orders shown with type badge, SL/TP prices, time from timestamps; Cancel SL / Cancel TP / Cancel Both
- **Funding column**: Details button replaced with low-contrast Info icon in positions, trader-history, and order-history tables

### Other
- `createZkOrder` type updated to exclude `"SLTP"` (SLTP uses separate flow)

## Dependencies

- `@twilight-dev/zkos-wasm` v0.1.4+ for `executeTradeLendOrderZkOSSlTp` and `cancelTraderOrderZkOSSlTp`

## Testing notes

- [ ] Place SLTP orders from Positions → Close → SL/TP
- [ ] Verify SLTP orders appear in Open Orders with correct type, prices, and time
- [ ] Cancel SL, TP, and both individually
- [ ] Confirm limit and SLTP orders are mutually exclusive (no limit + SLTP on same position)

## Known limitations

**This is an early draft.** Some UI and history fixes are expected before production readiness. Please report any issues or edge cases.